### PR TITLE
Add data_source tracking to support multiple data ingestion methods

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,5 @@
+export type DataSource = 'google_sheet' | 'plaid' | 'csv' | 'manual'
+
 export interface AccountBalance {
   id: string
   date_updated: string
@@ -11,6 +13,7 @@ export interface AccountBalance {
   liquidity_profile: string | null
   risk_profile: string | null
   horizon_profile: string | null
+  data_source?: DataSource
 }
 
 export interface TransactionLog {
@@ -22,6 +25,7 @@ export interface TransactionLog {
   amount_gbp: number | null
   /** Original transaction currency from sheet column F: 'USD' | 'GBP'. Used for per-currency burn. */
   currency?: string | null
+  data_source?: DataSource
 }
 
 export interface BudgetTarget {
@@ -33,6 +37,7 @@ export interface BudgetTarget {
   ytd_gbp: number
   tracking_est_usd: number
   ytd_usd: number
+  data_source?: DataSource
 }
 
 export interface HistoricalNetWorth {
@@ -117,6 +122,7 @@ export interface KidsAccount {
   date_updated: string
   notes: string | null
   purpose: string | null
+  data_source?: DataSource
 }
 
 // Debt tracking - mortgages, loans, credit cards
@@ -130,4 +136,5 @@ export interface Debt {
   amount_usd: number | null
   date_updated: string
   created_at: string
+  data_source?: DataSource
 }

--- a/supabase/migrations/023_data_source_tracking.sql
+++ b/supabase/migrations/023_data_source_tracking.sql
@@ -1,0 +1,24 @@
+-- Add data_source column to tables that will support multiple input methods
+ALTER TABLE account_balances
+  ADD COLUMN data_source TEXT NOT NULL DEFAULT 'google_sheet'
+  CHECK (data_source IN ('google_sheet', 'plaid', 'csv', 'manual'));
+
+ALTER TABLE transaction_log
+  ADD COLUMN data_source TEXT NOT NULL DEFAULT 'google_sheet'
+  CHECK (data_source IN ('google_sheet', 'plaid', 'csv', 'manual'));
+
+ALTER TABLE budget_targets
+  ADD COLUMN data_source TEXT NOT NULL DEFAULT 'google_sheet'
+  CHECK (data_source IN ('google_sheet', 'plaid', 'csv', 'manual'));
+
+ALTER TABLE debt
+  ADD COLUMN data_source TEXT NOT NULL DEFAULT 'google_sheet'
+  CHECK (data_source IN ('google_sheet', 'plaid', 'csv', 'manual'));
+
+ALTER TABLE kids_accounts
+  ADD COLUMN data_source TEXT NOT NULL DEFAULT 'google_sheet'
+  CHECK (data_source IN ('google_sheet', 'plaid', 'csv', 'manual'));
+
+-- Add index for filtering by source
+CREATE INDEX idx_transaction_log_data_source ON transaction_log(user_id, data_source);
+CREATE INDEX idx_account_balances_data_source ON account_balances(user_id, data_source);


### PR DESCRIPTION
Adds a data_source column (google_sheet | plaid | csv | manual) to account_balances, transaction_log, budget_targets, debt, and kids_accounts. Scopes sync service deletes to data_source='google_sheet' so future non-sheet data is preserved during syncs.