### PR TITLE
Fix weekly view empty data and add trend line labels for current/max …

### DIFF
--- a/components/analysis/monthly-category-trends-chart.tsx
+++ b/components/analysis/monthly-category-trends-chart.tsx
@@ -559,14 +559,19 @@ export function MonthlyCategoryTrendsChart({
                 content={(props: any) => {
                   const { x, y, payload } = props
                   if (!payload || chartData.length === 0) return null
-                  
-                  // Only show label for the last month (most recent)
-                  const isLastMonth = payload.periodLabel === chartData[chartData.length - 1]?.periodLabel
-                  if (!isLastMonth) return null
-                  
+
+                  // Find which data point has the max trend value
+                  const maxTrendPoint = chartData.reduce((max, d) => d.trendLine > max.trendLine ? d : max, chartData[0])
+                  const isMaxTrend = payload.periodLabel === maxTrendPoint?.periodLabel
+                  const isLastPeriod = payload.periodLabel === chartData[chartData.length - 1]?.periodLabel
+
+                  // Show label for the last period and the max trend period
+                  // Skip max if it's the same as last period (avoid duplicate)
+                  if (!isLastPeriod && !isMaxTrend) return null
+
                   const value = payload?.trendLine || 0
                   if (value === 0) return null
-                  
+
                   return (
                     <g transform={`translate(${x},${y - 12})`}>
                       <text

--- a/components/analysis/monthly-category-trends-section.tsx
+++ b/components/analysis/monthly-category-trends-section.tsx
@@ -38,9 +38,10 @@ export function MonthlyCategoryTrendsSection() {
       const supabase = createClient()
 
       // Get date range: last 13 months starting from last full month
+      // endDate extends to today so the weekly view can access current-month transactions
       const today = new Date()
       const lastFullMonth = new Date(today.getFullYear(), today.getMonth() - 1, 1)
-      const endDate = new Date(today.getFullYear(), today.getMonth(), 0)
+      const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate())
       endDate.setHours(23, 59, 59, 999)
       // Go back 12 months from last full month to get 13 months total
       // This gives us: lastFullMonth - 12 months = first month of the 13-month range


### PR DESCRIPTION
…values

- Extend transaction fetch endDate to today (was end of previous month), so weekly view can access current-month transactions for the latest full week
- This also fixes summary cards not appearing in weekly mode (same root cause)
- Add trend line labels for both the current (last) period value and the max trend value across all periods

https://claude.ai/code/session_015ridhNAgLNRh8J7EgkANRf