### PR TITLE
feat(forecast): add transaction-based Forecast page with three method…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,9 +201,10 @@ Sidebar order (`components/sidebar.tsx`):
 7. `Liquidity` (`/liquidity`)
 8. `Kids Accounts` (`/kids`) - hidden if no kids data
 9. `Analysis` (`/analysis`)
-10. `Recurring` (`/recurring`)
-11. `Import` (`/import`)
-12. `Settings` (`/settings`)
+10. `Forecast` (`/forecast`)
+11. `Recurring` (`/recurring`)
+12. `Import` (`/import`)
+13. `Settings` (`/settings`)
 
 ## API Routes
 

--- a/app/api/forecast/transaction-based/route.ts
+++ b/app/api/forecast/transaction-based/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { fetchTransactionForecast } from '@/lib/data/forecast-transaction-data'
+
+/**
+ * GET /api/forecast/transaction-based
+ *
+ * Returns the transaction-based forecast for the current user (no params).
+ * Response shape: TransactionForecastResult (see lib/forecast-transaction-based.ts).
+ */
+export async function GET() {
+  try {
+    const result = await fetchTransactionForecast()
+    if (!result) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    return NextResponse.json(result)
+  } catch (error) {
+    console.error('forecast/transaction-based error', error)
+    const message = error instanceof Error ? error.message : 'Failed to compute forecast'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/forecast/page.tsx
+++ b/app/forecast/page.tsx
@@ -1,0 +1,43 @@
+import { Suspense } from 'react'
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import { ForecastPageWrapper } from '@/components/forecast/forecast-page-wrapper'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default async function ForecastPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  return (
+    <div className="w-full max-w-7xl mx-auto space-y-3 md:space-y-4 flex flex-col">
+      <div>
+        <h1 className="text-2xl md:text-3xl font-bold">Forecast</h1>
+        <p className="text-sm md:text-base text-muted-foreground">
+          Three methodologies. Same data. The range across all three is your scenario band.
+        </p>
+      </div>
+
+      <Suspense fallback={<ForecastPageSkeleton />}>
+        <ForecastPageWrapper />
+      </Suspense>
+    </div>
+  )
+}
+
+function ForecastPageSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+      <Skeleton className="h-[360px] w-full" />
+      <Skeleton className="h-[480px] w-full" />
+    </div>
+  )
+}

--- a/components/forecast/forecast-backtest-panel.tsx
+++ b/components/forecast/forecast-backtest-panel.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useCurrency } from '@/lib/contexts/currency-context'
+import type { BacktestResult, MethodologyId } from '@/lib/forecast-transaction-based'
+import { Trophy } from 'lucide-react'
+
+const METHOD_LABEL: Record<MethodologyId, string> = {
+  m1: 'M1 Seasonal',
+  m2: 'M2 Seasonal+Trend',
+  m3: 'M3 Fixed+Variable',
+}
+
+export function ForecastBacktestPanel({ backtest }: { backtest: BacktestResult }) {
+  const { currency, convertAmount } = useCurrency()
+  const fmt = (gbp: number) =>
+    new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    }).format(convertAmount(gbp, 'GBP'))
+
+  const fmtPct = (n: number) => `${(n * 100).toFixed(1)}%`
+
+  // Sort categories by absolute spend descending for visual priority.
+  const rows = [...backtest.categories].sort((a, b) => b.actual - a.actual)
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg md:text-xl">Backtest — {backtest.year} accuracy</CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Each methodology was run on 1 Jan {backtest.year} using only data from before that year, then
+          compared to actual {backtest.year} spend.
+        </p>
+      </CardHeader>
+      <CardContent className="px-0 md:px-6">
+        <div className="px-3 md:px-0 mb-3 flex flex-wrap items-center gap-2">
+          <Trophy className="h-4 w-4 text-amber-500" />
+          <span className="text-sm">
+            Best methodology for your data:{' '}
+            <span className="font-semibold">{METHOD_LABEL[backtest.bestOverall]}</span>{' '}
+            <span className="text-muted-foreground">
+              ({fmtPct(backtest.totals[`${backtest.bestOverall}Mape`])} weighted MAPE)
+            </span>
+          </span>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="px-3 py-2 text-left">Category</th>
+                <th className="px-3 py-2 text-right">Actual</th>
+                <th className="px-3 py-2 text-right">M1</th>
+                <th className="px-3 py-2 text-right">M1 err</th>
+                <th className="px-3 py-2 text-right">M2</th>
+                <th className="px-3 py-2 text-right">M2 err</th>
+                <th className="px-3 py-2 text-right">M3</th>
+                <th className="px-3 py-2 text-right">M3 err</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((c) => {
+                const best = bestOf(c.m1Mape, c.m2Mape, c.m3Mape)
+                return (
+                  <tr key={c.category} className="border-b border-border/50">
+                    <td className="px-3 py-2 font-medium">{c.category}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{fmt(c.actual)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{fmt(c.m1)}</td>
+                    <td className={'px-3 py-2 text-right tabular-nums ' + mapeClass(c.m1Mape, best === 0)}>
+                      {fmtPct(c.m1Mape)}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{fmt(c.m2)}</td>
+                    <td className={'px-3 py-2 text-right tabular-nums ' + mapeClass(c.m2Mape, best === 1)}>
+                      {fmtPct(c.m2Mape)}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{fmt(c.m3)}</td>
+                    <td className={'px-3 py-2 text-right tabular-nums ' + mapeClass(c.m3Mape, best === 2)}>
+                      {fmtPct(c.m3Mape)}
+                    </td>
+                  </tr>
+                )
+              })}
+              <tr className="border-t-2 border-border bg-muted/30 font-semibold">
+                <td className="px-3 py-2">Total / Weighted MAPE</td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmt(backtest.totals.actual)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmt(backtest.totals.m1)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmtPct(backtest.totals.m1Mape)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmt(backtest.totals.m2)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmtPct(backtest.totals.m2Mape)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmt(backtest.totals.m3)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmtPct(backtest.totals.m3Mape)}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function bestOf(a: number, b: number, c: number): 0 | 1 | 2 {
+  const m = Math.min(a, b, c)
+  if (m === a) return 0
+  if (m === b) return 1
+  return 2
+}
+
+function mapeClass(mape: number, isBest: boolean): string {
+  if (isBest) return 'text-emerald-600 dark:text-emerald-400 font-semibold'
+  if (mape > 0.3) return 'text-amber-600 dark:text-amber-400'
+  return ''
+}

--- a/components/forecast/forecast-category-drilldown.tsx
+++ b/components/forecast/forecast-category-drilldown.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { X } from 'lucide-react'
+import { useCurrency } from '@/lib/contexts/currency-context'
+import { useIsMobile } from '@/lib/hooks/use-is-mobile'
+import { useChartTheme } from '@/lib/hooks/use-chart-theme'
+import {
+  getChartFontSizes,
+  getChartTooltipContentStyle,
+  getChartTooltipWrapperStyle,
+} from '@/lib/chart-styles'
+import {
+  ComposedChart,
+  Line,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  ReferenceLine,
+} from 'recharts'
+import type { TransactionForecastResult } from '@/lib/forecast-transaction-based'
+
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+export function ForecastCategoryDrilldown({
+  data,
+  category,
+  onClose,
+}: {
+  data: TransactionForecastResult
+  category: string
+  onClose: () => void
+}) {
+  const { currency, convertAmount } = useCurrency()
+  const isMobile = useIsMobile()
+  const chartTheme = useChartTheme()
+  const fontSizes = getChartFontSizes(isMobile)
+
+  const m1 = data.methodologies.find((m) => m.id === 'm1')!.byCategory.find((c) => c.category === category)
+  const m2 = data.methodologies.find((m) => m.id === 'm2')!.byCategory.find((c) => c.category === category)
+  const m3 = data.methodologies.find((m) => m.id === 'm3')!.byCategory.find((c) => c.category === category)
+  const ens = data.ensemble.categories.find((c) => c.category === category)
+
+  const fmtCompact = (n: number) =>
+    new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency,
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(n)
+
+  const fmtFull = (n: number) =>
+    new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    }).format(n)
+
+  const chartData = useMemo(() => {
+    if (!m1 || !m2 || !m3 || !ens) return []
+    return MONTH_LABELS.map((label, i) => {
+      const type = ens.monthType[i]
+      const isPast = type === 'actual'
+      const showForecast = type !== 'actual'
+      return {
+        month: label,
+        actual: isPast ? convertAmount(m1.months[i], 'GBP') : null,
+        m1: showForecast ? convertAmount(m1.months[i], 'GBP') : null,
+        m2: showForecast ? convertAmount(m2.months[i], 'GBP') : null,
+        m3: showForecast ? convertAmount(m3.months[i], 'GBP') : null,
+        low: showForecast ? convertAmount(ens.monthsLow[i], 'GBP') : null,
+        high: showForecast ? convertAmount(ens.monthsHigh[i], 'GBP') : null,
+        monthType: type,
+      }
+    })
+  }, [m1, m2, m3, ens, convertAmount])
+
+  if (!ens || !m1 || !m2 || !m3) {
+    return null
+  }
+
+  const tooltipContent = ({ active, payload, label }: any) => {
+    if (!active || !payload?.length) return null
+    const row = payload[0]?.payload
+    if (!row) return null
+    const progressPct = Math.round((data.ensemble.currentMonthProgress ?? 0) * 100)
+    const titleSuffix =
+      row.monthType === 'partial'
+        ? ` (MTD + projection, ${progressPct}% elapsed)`
+        : row.monthType === 'forecast'
+          ? ' (forecast)'
+          : ''
+    return (
+      <div style={getChartTooltipContentStyle(chartTheme, { isMobile })} className="text-xs">
+        <div className="font-semibold mb-1">
+          {label} {data.year}
+          <span className="font-normal text-muted-foreground">{titleSuffix}</span>
+        </div>
+        {row.monthType === 'actual' ? (
+          <div>Actual: <span className="font-medium">{fmtFull(row.actual ?? 0)}</span></div>
+        ) : (
+          <>
+            <div>M1 Seasonal: {fmtFull(row.m1 ?? 0)}</div>
+            <div>M2 Seasonal+Trend: {fmtFull(row.m2 ?? 0)}</div>
+            <div>M3 Fixed+Variable: {fmtFull(row.m3 ?? 0)}</div>
+            <div className="mt-1 pt-1 border-t border-border text-muted-foreground">
+              Range: {fmtFull(row.low ?? 0)} – {fmtFull(row.high ?? 0)}
+            </div>
+          </>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-2 pb-2">
+        <div>
+          <CardTitle className="text-lg md:text-xl">{category} — methodology comparison</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            Actuals through {MONTH_LABELS[Math.max(0, data.currentMonth - 1)]} {data.year}, then each
+            methodology&apos;s remaining-month forecast.
+          </p>
+        </div>
+        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+          <X className="h-4 w-4" />
+        </Button>
+      </CardHeader>
+      <CardContent className="px-2 md:px-6">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-3 text-sm">
+          <Stat label="YTD" value={fmtFull(convertAmount(ens.ytd, 'GBP'))} />
+          <Stat label="M1 Seasonal" value={fmtFull(convertAmount(ens.byMethodology.m1, 'GBP'))} />
+          <Stat label="M2 Seasonal+Trend" value={fmtFull(convertAmount(ens.byMethodology.m2, 'GBP'))} />
+          <Stat label="M3 Fixed+Variable" value={fmtFull(convertAmount(ens.byMethodology.m3, 'GBP'))} />
+        </div>
+
+        <div className="h-[280px] md:h-[320px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={chartData} margin={{ top: 10, right: 10, bottom: 0, left: 0 }}>
+              <CartesianGrid stroke={chartTheme.gridStroke} strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="month" stroke={chartTheme.axisStroke} tick={{ fontSize: fontSizes.axisTick }} />
+              <YAxis
+                stroke={chartTheme.axisStroke}
+                tick={{ fontSize: fontSizes.axisTick }}
+                tickFormatter={fmtCompact}
+                width={isMobile ? 50 : 70}
+              />
+              <Tooltip
+                content={tooltipContent}
+                wrapperStyle={getChartTooltipWrapperStyle(chartTheme)}
+                cursor={{ stroke: chartTheme.gridStroke, opacity: 0.5 }}
+              />
+              <Legend wrapperStyle={{ fontSize: fontSizes.legend }} iconSize={fontSizes.iconSize} />
+              <Area
+                type="monotone"
+                dataKey="high"
+                stroke="none"
+                fill="#6366f1"
+                fillOpacity={0.12}
+                connectNulls={false}
+                isAnimationActive={false}
+                legendType="none"
+              />
+              <Area
+                type="monotone"
+                dataKey="low"
+                stroke="none"
+                fill={chartTheme.isDark ? '#0b0f1a' : '#ffffff'}
+                fillOpacity={1}
+                connectNulls={false}
+                isAnimationActive={false}
+                legendType="none"
+              />
+              <Line
+                type="monotone"
+                dataKey="actual"
+                name="Actual"
+                stroke="#10b981"
+                strokeWidth={2}
+                dot={{ r: 3 }}
+                connectNulls={false}
+              />
+              <Line type="monotone" dataKey="m1" name="M1 Seasonal" stroke="#6366f1" strokeWidth={2} dot={false} connectNulls={false} />
+              <Line type="monotone" dataKey="m2" name="M2 Seasonal+Trend" stroke="#f59e0b" strokeWidth={2} dot={false} connectNulls={false} />
+              <Line type="monotone" dataKey="m3" name="M3 Fixed+Variable" stroke="#ec4899" strokeWidth={2} dot={false} connectNulls={false} />
+              <ReferenceLine
+                x={MONTH_LABELS[Math.max(0, data.currentMonth - 1)]}
+                stroke={chartTheme.axisStroke}
+                strokeDasharray="3 3"
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="text-sm md:text-base font-semibold tabular-nums">{value}</div>
+    </div>
+  )
+}

--- a/components/forecast/forecast-category-table.tsx
+++ b/components/forecast/forecast-category-table.tsx
@@ -1,0 +1,255 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { useCurrency } from '@/lib/contexts/currency-context'
+import type {
+  EnsembleCategory,
+  TransactionForecastResult,
+} from '@/lib/forecast-transaction-based'
+import { ChevronDown, ChevronUp, ArrowUpDown } from 'lucide-react'
+
+type SortKey =
+  | 'category'
+  | 'ytd'
+  | 'm1'
+  | 'm2'
+  | 'm3'
+  | 'fullYearBase'
+  | 'range'
+  | 'priorYear'
+
+type SortDir = 'asc' | 'desc'
+
+export function ForecastCategoryTable({
+  data,
+  categories,
+  selectedCategory,
+  onSelectCategory,
+}: {
+  data: TransactionForecastResult
+  categories: EnsembleCategory[]
+  selectedCategory: string | null
+  onSelectCategory: (cat: string | null) => void
+}) {
+  const { currency, convertAmount } = useCurrency()
+  const [sortKey, setSortKey] = useState<SortKey>('fullYearBase')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  const fmt = (gbp: number) =>
+    new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    }).format(convertAmount(gbp, 'GBP'))
+
+  const sorted = useMemo(() => {
+    const list = [...categories]
+    list.sort((a, b) => {
+      const av = readKey(a, sortKey)
+      const bv = readKey(b, sortKey)
+      if (typeof av === 'string' && typeof bv === 'string') {
+        return sortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av)
+      }
+      const ax = Number(av) || 0
+      const bx = Number(bv) || 0
+      return sortDir === 'asc' ? ax - bx : bx - ax
+    })
+    return list
+  }, [categories, sortKey, sortDir])
+
+  const setSort = (k: SortKey) => {
+    if (k === sortKey) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    else {
+      setSortKey(k)
+      setSortDir(k === 'category' ? 'asc' : 'desc')
+    }
+  }
+
+  const sortIcon = (k: SortKey) => {
+    if (k !== sortKey) return <ArrowUpDown className="h-3 w-3 opacity-40" />
+    return sortDir === 'asc' ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />
+  }
+
+  const totals = data.ensemble.totals
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg md:text-xl">Forecast by category</CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Click a category to see its full history and remaining-month forecast lines.
+        </p>
+      </CardHeader>
+      <CardContent className="px-0 md:px-6">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-xs uppercase tracking-wide text-muted-foreground">
+                <Th onClick={() => setSort('category')} icon={sortIcon('category')} align="left">
+                  Category
+                </Th>
+                <Th onClick={() => setSort('ytd')} icon={sortIcon('ytd')} align="right">
+                  YTD
+                </Th>
+                <Th onClick={() => setSort('m1')} icon={sortIcon('m1')} align="right">
+                  M1 FY
+                </Th>
+                <Th onClick={() => setSort('m2')} icon={sortIcon('m2')} align="right">
+                  M2 FY
+                </Th>
+                <Th onClick={() => setSort('m3')} icon={sortIcon('m3')} align="right">
+                  M3 FY
+                </Th>
+                <Th onClick={() => setSort('range')} icon={sortIcon('range')} align="right">
+                  Range
+                </Th>
+                <Th onClick={() => setSort('fullYearBase')} icon={sortIcon('fullYearBase')} align="right">
+                  Base FY
+                </Th>
+                <Th onClick={() => setSort('priorYear')} icon={sortIcon('priorYear')} align="right">
+                  vs PY
+                </Th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((c) => {
+                const isSelected = selectedCategory === c.category
+                const range = c.fullYearHigh - c.fullYearLow
+                const pyDelta =
+                  c.priorYearActual > 0
+                    ? ((c.fullYearBase - c.priorYearActual) / c.priorYearActual) * 100
+                    : null
+                return (
+                  <tr
+                    key={c.category}
+                    onClick={() => onSelectCategory(isSelected ? null : c.category)}
+                    className={
+                      'cursor-pointer border-b border-border/50 transition-colors hover:bg-muted/40 ' +
+                      (isSelected ? 'bg-muted/60' : '')
+                    }
+                  >
+                    <td className="px-3 py-2 font-medium">{c.category}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{fmt(c.ytd)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{fmt(c.byMethodology.m1)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{fmt(c.byMethodology.m2)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{fmt(c.byMethodology.m3)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-xs text-muted-foreground">
+                      {fmt(c.fullYearLow)}
+                      <span className="px-1">–</span>
+                      {fmt(c.fullYearHigh)}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums font-semibold">{fmt(c.fullYearBase)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">
+                      {pyDelta == null ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        <span
+                          className={
+                            pyDelta >= 0
+                              ? 'text-amber-600 dark:text-amber-400'
+                              : 'text-emerald-600 dark:text-emerald-400'
+                          }
+                        >
+                          {pyDelta >= 0 ? '+' : ''}
+                          {pyDelta.toFixed(0)}%
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+              <tr className="border-t-2 border-border bg-muted/30 font-semibold">
+                <td className="px-3 py-2">Total</td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmt(totals.ytd)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmt(totals.byMethodology.m1)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmt(totals.byMethodology.m2)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmt(totals.byMethodology.m3)}</td>
+                <td className="px-3 py-2 text-right tabular-nums text-xs">
+                  {fmt(totals.fullYearLow)}
+                  <span className="px-1">–</span>
+                  {fmt(totals.fullYearHigh)}
+                </td>
+                <td className="px-3 py-2 text-right tabular-nums">{fmt(totals.fullYearBase)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">
+                  {totals.priorYearActual > 0 ? (
+                    <span>
+                      {((totals.fullYearBase - totals.priorYearActual) / totals.priorYearActual) * 100 >= 0
+                        ? '+'
+                        : ''}
+                      {(((totals.fullYearBase - totals.priorYearActual) / totals.priorYearActual) * 100).toFixed(0)}%
+                    </span>
+                  ) : (
+                    '—'
+                  )}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        {selectedCategory && (
+          <div className="px-3 pt-3">
+            <Button variant="ghost" size="sm" onClick={() => onSelectCategory(null)}>
+              Clear selection
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function readKey(c: EnsembleCategory, k: SortKey): number | string {
+  switch (k) {
+    case 'category':
+      return c.category
+    case 'ytd':
+      return c.ytd
+    case 'm1':
+      return c.byMethodology.m1
+    case 'm2':
+      return c.byMethodology.m2
+    case 'm3':
+      return c.byMethodology.m3
+    case 'fullYearBase':
+      return c.fullYearBase
+    case 'range':
+      return c.fullYearHigh - c.fullYearLow
+    case 'priorYear':
+      return c.priorYearActual > 0 ? c.fullYearBase / c.priorYearActual : 0
+  }
+}
+
+function Th({
+  children,
+  onClick,
+  icon,
+  align,
+}: {
+  children: React.ReactNode
+  onClick: () => void
+  icon: React.ReactNode
+  align: 'left' | 'right'
+}) {
+  return (
+    <th
+      onClick={onClick}
+      className={
+        'cursor-pointer select-none px-3 py-2 ' +
+        (align === 'right' ? 'text-right' : 'text-left')
+      }
+    >
+      <div
+        className={
+          'inline-flex items-center gap-1 hover:text-foreground transition-colors ' +
+          (align === 'right' ? 'flex-row-reverse' : '')
+        }
+      >
+        <span>{children}</span>
+        {icon}
+      </div>
+    </th>
+  )
+}

--- a/components/forecast/forecast-methodology-notes.tsx
+++ b/components/forecast/forecast-methodology-notes.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { TransactionForecastResult } from '@/lib/forecast-transaction-based'
+
+export function ForecastMethodologyNotes({ data }: { data: TransactionForecastResult }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg md:text-xl">How these forecasts work</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <details className="text-sm">
+          <summary className="cursor-pointer font-medium text-muted-foreground hover:text-foreground">
+            Methodology details
+          </summary>
+          <div className="mt-3 space-y-3 text-sm leading-relaxed">
+            <div>
+              <div className="font-semibold">M1 — Seasonal Average</div>
+              <p className="text-muted-foreground">
+                For each category, takes the trailing 3-year mean of every calendar month. Each remaining
+                month of {data.year} is forecast as that month&apos;s historical mean. Stable; captures
+                seasonality (e.g. holidays, annual subscriptions); ignores trend.
+              </p>
+            </div>
+            <div>
+              <div className="font-semibold">M2 — Seasonal + Trend</div>
+              <p className="text-muted-foreground">
+                Computes a seasonal index from the trailing 3 years and a category-specific YoY growth rate
+                (geometric mean of YoY ratios, clamped to ±30%). Forecast = projected annual × seasonal
+                index. Adds inflation / lifestyle drift on top of the seasonal pattern.
+              </p>
+            </div>
+            <div>
+              <div className="font-semibold">M3 — Fixed + Variable</div>
+              <p className="text-muted-foreground">
+                Detects recurring fixed spend by clustering transactions on counterparty + amount band that
+                fired in 9+ of the last 12 months. The fixed amount is carried forward unchanged. Variable
+                spend (everything not classified as fixed) is forecast using the trailing-12-month variable
+                mean weighted by the seasonal index. Most informative when you have lots of subscriptions
+                and bills.
+              </p>
+            </div>
+            <div>
+              <div className="font-semibold">Range across methodologies</div>
+              <p className="text-muted-foreground">
+                For every month and every category, we take the min / median / max across the three
+                methodologies. The base forecast is the median; the band between min and max is the
+                scenario range. A wide band means the methodologies disagree — typically a sign of high
+                variance in that category.
+              </p>
+            </div>
+            <div>
+              <div className="font-semibold">Current month handling</div>
+              <p className="text-muted-foreground">
+                Past completed months are pure actuals. The current month is{' '}
+                <span className="font-medium">MTD + remaining-days projection</span>: month-to-date spend
+                plus <code>(1 − day/days_in_month) × monthly_estimate</code>, where the monthly estimate
+                comes from each methodology&apos;s own model. The full-year forecast = past actuals +
+                current-month MTD + current-month remainder + future-month forecasts.
+              </p>
+            </div>
+            <div>
+              <div className="font-semibold">Excluded from forecast</div>
+              <p className="text-muted-foreground">
+                Income, Other Income, Gift Money, and Excluded categories are filtered out. Only expense
+                spend is forecast.
+              </p>
+            </div>
+          </div>
+        </details>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/forecast/forecast-monthly-chart.tsx
+++ b/components/forecast/forecast-monthly-chart.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useCurrency } from '@/lib/contexts/currency-context'
+import { useIsMobile } from '@/lib/hooks/use-is-mobile'
+import { useChartTheme } from '@/lib/hooks/use-chart-theme'
+import {
+  getChartFontSizes,
+  getChartTooltipContentStyle,
+  getChartTooltipWrapperStyle,
+} from '@/lib/chart-styles'
+import {
+  ComposedChart,
+  Bar,
+  Line,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  ReferenceLine,
+  Cell,
+} from 'recharts'
+import type { TransactionForecastResult } from '@/lib/forecast-transaction-based'
+
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+export function ForecastMonthlyChart({ data }: { data: TransactionForecastResult }) {
+  const { currency, convertAmount } = useCurrency()
+  const isMobile = useIsMobile()
+  const chartTheme = useChartTheme()
+  const fontSizes = getChartFontSizes(isMobile)
+
+  const t = data.ensemble.totals
+  const m1 = data.methodologies.find((m) => m.id === 'm1')!
+  const m2 = data.methodologies.find((m) => m.id === 'm2')!
+  const m3 = data.methodologies.find((m) => m.id === 'm3')!
+
+  const m1ByMonth = sumAllCategories(m1)
+  const m2ByMonth = sumAllCategories(m2)
+  const m3ByMonth = sumAllCategories(m3)
+
+  const chartData = MONTH_LABELS.map((label, i) => {
+    const type = t.monthType[i]
+    const isPast = type === 'actual'
+    // 'partial' and 'forecast' both have methodology spread; both render as forecast bars.
+    const showForecast = type !== 'actual'
+    return {
+      month: label,
+      actual: isPast ? convertAmount(t.monthsBase[i], 'GBP') : null,
+      forecast: showForecast ? convertAmount(t.monthsBase[i], 'GBP') : null,
+      low: showForecast ? convertAmount(t.monthsLow[i], 'GBP') : null,
+      high: showForecast ? convertAmount(t.monthsHigh[i], 'GBP') : null,
+      m1: showForecast ? convertAmount(m1ByMonth[i], 'GBP') : null,
+      m2: showForecast ? convertAmount(m2ByMonth[i], 'GBP') : null,
+      m3: showForecast ? convertAmount(m3ByMonth[i], 'GBP') : null,
+      monthType: type,
+    }
+  })
+
+  const fmtCompact = (n: number) =>
+    new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency,
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(n)
+
+  const fmtFull = (n: number) =>
+    new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    }).format(n)
+
+  const progressPct = Math.round((data.ensemble.currentMonthProgress ?? 0) * 100)
+
+  const tooltipContent = ({ active, payload, label }: any) => {
+    if (!active || !payload?.length) return null
+    const row = payload[0]?.payload
+    if (!row) return null
+    const titleSuffix =
+      row.monthType === 'partial'
+        ? ` (MTD + projection, ${progressPct}% elapsed)`
+        : row.monthType === 'forecast'
+          ? ' (forecast)'
+          : ''
+    return (
+      <div
+        style={getChartTooltipContentStyle(chartTheme, { isMobile })}
+        className="text-xs"
+      >
+        <div className="font-semibold mb-1">
+          {label} {data.year}
+          <span className="font-normal text-muted-foreground">{titleSuffix}</span>
+        </div>
+        {row.monthType === 'actual' ? (
+          <div>
+            <span className="text-muted-foreground">Actual:</span>{' '}
+            <span className="font-medium">{fmtFull(row.actual ?? 0)}</span>
+          </div>
+        ) : (
+          <>
+            <div>
+              <span className="text-muted-foreground">Base:</span>{' '}
+              <span className="font-medium">{fmtFull(row.forecast ?? 0)}</span>
+            </div>
+            <div className="text-muted-foreground">
+              Range: {fmtFull(row.low ?? 0)} – {fmtFull(row.high ?? 0)}
+            </div>
+            <div className="mt-1 pt-1 border-t border-border">
+              <div>M1 Seasonal: {fmtFull(row.m1 ?? 0)}</div>
+              <div>M2 Seasonal+Trend: {fmtFull(row.m2 ?? 0)}</div>
+              <div>M3 Fixed+Variable: {fmtFull(row.m3 ?? 0)}</div>
+            </div>
+          </>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg md:text-xl">Month-by-month forecast</CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Solid bars are completed-month actuals. The current month is MTD plus a remaining-days projection
+          ({progressPct}% elapsed). Lighter bars are ensemble base forecast for future months; shaded band
+          shows the low/high range across the three methodologies.
+        </p>
+      </CardHeader>
+      <CardContent className="px-2 md:px-6">
+        <div className="h-[320px] md:h-[360px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart
+              data={chartData}
+              margin={{ top: 10, right: 10, bottom: 0, left: 0 }}
+            >
+              <CartesianGrid stroke={chartTheme.gridStroke} strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="month" stroke={chartTheme.axisStroke} tick={{ fontSize: fontSizes.axisTick }} />
+              <YAxis
+                stroke={chartTheme.axisStroke}
+                tick={{ fontSize: fontSizes.axisTick }}
+                tickFormatter={fmtCompact}
+                width={isMobile ? 50 : 70}
+              />
+              <Tooltip
+                content={tooltipContent}
+                wrapperStyle={getChartTooltipWrapperStyle(chartTheme)}
+                cursor={{ fill: chartTheme.gridStroke, opacity: 0.3 }}
+              />
+              <Legend
+                wrapperStyle={{ fontSize: fontSizes.legend }}
+                iconSize={fontSizes.iconSize}
+              />
+              {/* Forecast band — translucent area between low/high overlaid on forecast months */}
+              <Area
+                type="monotone"
+                dataKey="high"
+                stroke="none"
+                fill="#6366f1"
+                fillOpacity={0.12}
+                connectNulls={false}
+                isAnimationActive={false}
+                legendType="none"
+              />
+              <Area
+                type="monotone"
+                dataKey="low"
+                stroke="none"
+                fill={chartTheme.isDark ? '#0b0f1a' : '#ffffff'}
+                fillOpacity={1}
+                connectNulls={false}
+                isAnimationActive={false}
+                legendType="none"
+              />
+              <Bar dataKey="actual" name="Actual" fill="#10b981" radius={[3, 3, 0, 0]} />
+              <Bar dataKey="forecast" name="Forecast (base)" fill="#6366f1" radius={[3, 3, 0, 0]} fillOpacity={0.85} />
+              <ReferenceLine
+                x={MONTH_LABELS[Math.max(0, data.currentMonth - 1)]}
+                stroke={chartTheme.axisStroke}
+                strokeDasharray="3 3"
+                label={{
+                  value: 'now',
+                  position: 'top',
+                  fill: chartTheme.labelFill,
+                  fontSize: fontSizes.axisTick,
+                }}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function sumAllCategories(m: TransactionForecastResult['methodologies'][number]): number[] {
+  const out = new Array(12).fill(0)
+  for (const c of m.byCategory) {
+    for (let i = 0; i < 12; i++) out[i] += c.months[i]
+  }
+  return out
+}

--- a/components/forecast/forecast-page-client.tsx
+++ b/components/forecast/forecast-page-client.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useState } from 'react'
+import { useTransactionForecast } from '@/lib/hooks/queries/use-transaction-forecast'
+import type { TransactionForecastResult } from '@/lib/forecast-transaction-based'
+import { Card, CardContent } from '@/components/ui/card'
+import { AlertCircle } from 'lucide-react'
+import { ForecastSummaryCards } from './forecast-summary-cards'
+import { ForecastMonthlyChart } from './forecast-monthly-chart'
+import { ForecastCategoryTable } from './forecast-category-table'
+import { ForecastCategoryDrilldown } from './forecast-category-drilldown'
+import { ForecastBacktestPanel } from './forecast-backtest-panel'
+import { ForecastMethodologyNotes } from './forecast-methodology-notes'
+
+export function ForecastPageClient({
+  initialData,
+}: {
+  initialData: TransactionForecastResult | null
+}) {
+  const { data, error, isLoading } = useTransactionForecast(initialData)
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
+
+  if (error) {
+    return (
+      <Card className="border-destructive/40">
+        <CardContent className="flex items-center gap-3 py-4">
+          <AlertCircle className="h-5 w-5 text-destructive" />
+          <div className="text-sm text-destructive">
+            {error instanceof Error ? error.message : 'Failed to load forecast.'}
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!data || isLoading) {
+    return (
+      <div className="text-sm text-muted-foreground">Loading forecast…</div>
+    )
+  }
+
+  const categoriesWithSpend = data.ensemble.categories.filter(
+    (c) => c.fullYearBase > 0 || c.ytd > 0,
+  )
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      <section id="forecast-summary" className="scroll-mt-24">
+        <ForecastSummaryCards data={data} />
+      </section>
+
+      <section
+        id="forecast-monthly-chart"
+        className="scroll-mt-24 pt-3 md:pt-4 border-t border-border"
+      >
+        <ForecastMonthlyChart data={data} />
+      </section>
+
+      <section
+        id="forecast-category-table"
+        className="scroll-mt-24 pt-3 md:pt-4 border-t border-border"
+      >
+        <ForecastCategoryTable
+          data={data}
+          categories={categoriesWithSpend}
+          selectedCategory={selectedCategory}
+          onSelectCategory={setSelectedCategory}
+        />
+      </section>
+
+      {selectedCategory && (
+        <section
+          id="forecast-category-drilldown"
+          className="scroll-mt-24 pt-3 md:pt-4 border-t border-border"
+        >
+          <ForecastCategoryDrilldown
+            data={data}
+            category={selectedCategory}
+            onClose={() => setSelectedCategory(null)}
+          />
+        </section>
+      )}
+
+      {data.backtest && (
+        <section
+          id="forecast-backtest"
+          className="scroll-mt-24 pt-3 md:pt-4 border-t border-border"
+        >
+          <ForecastBacktestPanel backtest={data.backtest} />
+        </section>
+      )}
+
+      <section
+        id="forecast-methodology"
+        className="scroll-mt-24 pt-3 md:pt-4 border-t border-border"
+      >
+        <ForecastMethodologyNotes data={data} />
+      </section>
+    </div>
+  )
+}

--- a/components/forecast/forecast-page-wrapper.tsx
+++ b/components/forecast/forecast-page-wrapper.tsx
@@ -1,0 +1,7 @@
+import { fetchTransactionForecast } from '@/lib/data/forecast-transaction-data'
+import { ForecastPageClient } from './forecast-page-client'
+
+export async function ForecastPageWrapper() {
+  const initial = await fetchTransactionForecast()
+  return <ForecastPageClient initialData={initial} />
+}

--- a/components/forecast/forecast-summary-cards.tsx
+++ b/components/forecast/forecast-summary-cards.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { Card, CardContent } from '@/components/ui/card'
+import { useCurrency } from '@/lib/contexts/currency-context'
+import type { TransactionForecastResult } from '@/lib/forecast-transaction-based'
+import { TrendingDown, TrendingUp } from 'lucide-react'
+
+export function ForecastSummaryCards({ data }: { data: TransactionForecastResult }) {
+  const { currency, convertAmount } = useCurrency()
+  const t = data.ensemble.totals
+
+  const fmt = (gbp: number) =>
+    new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    }).format(convertAmount(gbp, 'GBP'))
+
+  const ytdConsumed = t.fullYearBase > 0 ? (t.ytd / t.fullYearBase) * 100 : 0
+  const pyDelta = t.priorYearActual > 0 ? ((t.fullYearBase - t.priorYearActual) / t.priorYearActual) * 100 : null
+  const range = t.fullYearHigh - t.fullYearLow
+  const rangePct = t.fullYearBase > 0 ? (range / t.fullYearBase) * 100 : 0
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <Card>
+        <CardContent className="p-4">
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">YTD actual</div>
+          <div className="mt-1 text-xl md:text-2xl font-semibold">{fmt(t.ytd)}</div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {ytdConsumed.toFixed(0)}% of base full-year
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-4">
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+            Full-year base
+          </div>
+          <div className="mt-1 text-xl md:text-2xl font-semibold">{fmt(t.fullYearBase)}</div>
+          <div className="mt-1 text-xs text-muted-foreground">Median across methodologies</div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-4">
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+            Scenario range
+          </div>
+          <div className="mt-1 text-xl md:text-2xl font-semibold tabular-nums">
+            {fmt(t.fullYearLow)}
+            <span className="px-1 text-muted-foreground">–</span>
+            {fmt(t.fullYearHigh)}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            ±{fmt(range / 2)} ({rangePct.toFixed(0)}% of base)
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-4">
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+            vs {data.year - 1} actual
+          </div>
+          <div className="mt-1 flex items-baseline gap-1.5">
+            {pyDelta == null ? (
+              <span className="text-xl md:text-2xl font-semibold text-muted-foreground">—</span>
+            ) : (
+              <>
+                {pyDelta >= 0 ? (
+                  <TrendingUp className="h-5 w-5 text-amber-500" />
+                ) : (
+                  <TrendingDown className="h-5 w-5 text-emerald-500" />
+                )}
+                <span
+                  className={
+                    'text-xl md:text-2xl font-semibold ' +
+                    (pyDelta >= 0 ? 'text-amber-600 dark:text-amber-400' : 'text-emerald-600 dark:text-emerald-400')
+                  }
+                >
+                  {pyDelta >= 0 ? '+' : ''}
+                  {pyDelta.toFixed(1)}%
+                </span>
+              </>
+            )}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {fmt(t.priorYearActual)} prior year
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { cn } from '@/utils/cn'
-import { LayoutDashboard, Wallet, Receipt, TrendingUp, Lightbulb, ChevronLeft, ChevronRight, Repeat, Baby, MoreHorizontal, Settings, Droplets, FileUp, MessageCircle, LogOut, Calendar, LayoutList } from 'lucide-react'
+import { LayoutDashboard, Wallet, Receipt, TrendingUp, Lightbulb, ChevronLeft, ChevronRight, Repeat, Baby, MoreHorizontal, Settings, Droplets, FileUp, MessageCircle, LogOut, Calendar, LayoutList, LineChart } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -24,6 +24,7 @@ const allNavigation = [
   { name: 'Liquidity', href: '/liquidity', icon: Droplets },
   { name: 'Kids Accounts', href: '/kids', icon: Baby },
   { name: 'Analysis', href: '/analysis', icon: TrendingUp },
+  { name: 'Forecast', href: '/forecast', icon: LineChart },
   { name: 'Recurring', href: '/recurring', icon: Repeat },
   { name: 'Import', href: '/import', icon: FileUp },
   { name: 'Settings', href: '/settings', icon: Settings },

--- a/lib/data/forecast-transaction-data.ts
+++ b/lib/data/forecast-transaction-data.ts
@@ -1,0 +1,84 @@
+import { cache } from 'react'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createClient } from '@/lib/supabase/server'
+import {
+  computeTransactionForecast,
+  TRAINING_YEARS,
+  type ForecastTxRow,
+  type TransactionForecastResult,
+} from '@/lib/forecast-transaction-based'
+
+const PAGE_SIZE = 1000
+
+async function fetchTransactionsForForecast(
+  supabase: SupabaseClient,
+  userId: string,
+  startDate: string,
+): Promise<ForecastTxRow[]> {
+  const buildQuery = (from: number, to: number) =>
+    supabase
+      .from('transaction_log')
+      .select('date, category, counterparty, amount_gbp, amount_usd', { count: 'exact' })
+      .eq('user_id', userId)
+      .gte('date', startDate)
+      .order('date', { ascending: true })
+      .range(from, to)
+
+  const { data: firstPage, count, error } = await buildQuery(0, PAGE_SIZE - 1)
+  if (error) {
+    console.error('fetchTransactionsForForecast error', error)
+    return (firstPage ?? []) as ForecastTxRow[]
+  }
+  const rows = (firstPage ?? []) as ForecastTxRow[]
+  const total = count ?? rows.length
+  const remainingPages = Math.ceil((total - rows.length) / PAGE_SIZE)
+  if (remainingPages <= 0) return rows
+  const rest = await Promise.all(
+    Array.from({ length: remainingPages }, (_, i) =>
+      buildQuery((i + 1) * PAGE_SIZE, (i + 2) * PAGE_SIZE - 1).then(
+        (r) => (r.data ?? []) as ForecastTxRow[],
+      ),
+    ),
+  )
+  return rows.concat(...rest)
+}
+
+async function fetchFxRateGBPUSD(supabase: SupabaseClient): Promise<number> {
+  const { data } = await supabase.from('fx_rate_current').select('gbpusd_rate').limit(1).single()
+  const rate = data?.gbpusd_rate
+  return rate && rate > 0 ? rate : 1.25
+}
+
+/**
+ * Server-side, request-deduped fetch + compute. Returns the full transaction-based
+ * forecast for the current authenticated user.
+ *
+ * Pulls trailing-(TRAINING_YEARS+1) calendar years of data so that the backtest has
+ * enough lookback to also use TRAINING_YEARS of training data. Returns null if
+ * unauthenticated or on hard error.
+ */
+export const fetchTransactionForecast = cache(
+  async (): Promise<TransactionForecastResult | null> => {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return null
+
+    const now = new Date()
+    // Backtest needs (currentYear - 1) plus TRAINING_YEARS of prior data; pull a year extra for safety.
+    const startYear = now.getFullYear() - (TRAINING_YEARS + 1)
+    const startDate = `${startYear}-01-01`
+
+    try {
+      const [rows, gbpUsdRate] = await Promise.all([
+        fetchTransactionsForForecast(supabase, user.id, startDate),
+        fetchFxRateGBPUSD(supabase),
+      ])
+      return computeTransactionForecast(rows, gbpUsdRate, now)
+    } catch (err) {
+      console.error('fetchTransactionForecast failed', err)
+      return null
+    }
+  },
+)

--- a/lib/forecast-transaction-based.ts
+++ b/lib/forecast-transaction-based.ts
@@ -1,0 +1,910 @@
+/**
+ * Transaction-based forecasting.
+ *
+ * Forecasts the current year's expense spend per category using ONLY the data in
+ * `transaction_log`. Three independent methodologies are computed and surfaced as a
+ * low / base / high range (min / median / max across the three).
+ *
+ * All amounts are returned in GBP. Caller converts at display time.
+ *
+ * Methodologies:
+ *   M1 — Seasonal Average: trailing-3y mean per (category, calendar month).
+ *   M2 — Seasonal + Trend: M1 seasonal index × trend-projected annual total.
+ *   M3 — Fixed/Variable: detect recurring fixed spend, project variable separately.
+ *
+ * The current year's months 1..currentMonth are always actuals (YTD), regardless of method.
+ */
+
+export const EXCLUDED_FROM_FORECAST = new Set([
+  'Excluded',
+  'Income',
+  'Other Income',
+  'Gift Money',
+])
+
+export const TRAINING_YEARS = 3
+
+export type ForecastTxRow = {
+  date: string // YYYY-MM-DD
+  category: string
+  counterparty: string | null
+  amount_gbp: number | null
+  amount_usd: number | null
+}
+
+export type MethodologyId = 'm1' | 'm2' | 'm3'
+
+export type CategoryMonthlyForecast = {
+  category: string
+  /** Length 12. Past months: actuals. Current month: MTD + remaining-days projection.
+   *  Future months: full-month forecast. GBP positive expenses. */
+  months: number[]
+  /** Length 12. 'actual' = past completed month; 'partial' = current month (MTD + projection);
+   *  'forecast' = future month. */
+  monthType: ('actual' | 'partial' | 'forecast')[]
+  /** Length 12. true if any portion of the month is actual data (past completed or current MTD). */
+  isActual: boolean[]
+  /** Sum of months[]. */
+  fullYear: number
+  /** YTD actuals only — through end of last completed month. Excludes current-month MTD. */
+  ytd: number
+}
+
+export type MethodologyResult = {
+  id: MethodologyId
+  label: string
+  description: string
+  byCategory: CategoryMonthlyForecast[]
+  /** Sum of fullYear across all categories. */
+  fullYearTotal: number
+  /** Sum of YTD across all categories. */
+  ytdTotal: number
+}
+
+export type EnsembleCategory = {
+  category: string
+  ytd: number
+  /** Length 12. Past months: actuals. Current month: MTD + median of methodologies'
+   *  remaining-days projections. Future months: median across methodologies. */
+  monthsBase: number[]
+  monthsLow: number[]
+  monthsHigh: number[]
+  /** Length 12. 'actual' | 'partial' | 'forecast'. */
+  monthType: ('actual' | 'partial' | 'forecast')[]
+  /** Length 12. true if any portion of the month is actual data. */
+  isActual: boolean[]
+  /** Per-methodology full-year totals for this category. */
+  byMethodology: { m1: number; m2: number; m3: number }
+  /** Min / median / max across methodologies for full year. */
+  fullYearLow: number
+  fullYearBase: number
+  fullYearHigh: number
+  /** Prior calendar year actuals total for this category (for vs-PY %). 0 if no data. */
+  priorYearActual: number
+}
+
+export type ForecastEnsemble = {
+  year: number
+  currentMonth: number // 1-12; YTD includes months 1..currentMonth - 1 fully, plus partial currentMonth
+  categories: EnsembleCategory[]
+  /** Aggregate (sum across categories) totals. */
+  totals: {
+    ytd: number
+    monthsBase: number[]
+    monthsLow: number[]
+    monthsHigh: number[]
+    monthType: ('actual' | 'partial' | 'forecast')[]
+    isActual: boolean[]
+    fullYearLow: number
+    fullYearBase: number
+    fullYearHigh: number
+    priorYearActual: number
+    byMethodology: { m1: number; m2: number; m3: number }
+  }
+  /** Day-of-month progress for the current month (0..1). 1 = month complete. */
+  currentMonthProgress: number
+}
+
+export type BacktestCategoryEntry = {
+  category: string
+  actual: number
+  m1: number
+  m2: number
+  m3: number
+  /** Mean Absolute Percent Error per methodology, capped at 1000%. */
+  m1Mape: number
+  m2Mape: number
+  m3Mape: number
+}
+
+export type BacktestResult = {
+  /** Year that was forecast (most recent completed year). */
+  year: number
+  categories: BacktestCategoryEntry[]
+  totals: {
+    actual: number
+    m1: number
+    m2: number
+    m3: number
+    m1Mape: number
+    m2Mape: number
+    m3Mape: number
+  }
+  /** Lowest-overall-MAPE methodology id. */
+  bestOverall: MethodologyId
+}
+
+export type TransactionForecastResult = {
+  /** As-of date (typically today). */
+  asOf: string
+  year: number
+  currentMonth: number
+  ensemble: ForecastEnsemble
+  methodologies: MethodologyResult[]
+  backtest: BacktestResult | null
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const normalizeAmountGBP = (
+  amountGBP: number | null,
+  amountUSD: number | null,
+  gbpUsdRate: number,
+): number => {
+  if (amountGBP != null && !Number.isNaN(Number(amountGBP))) return Number(amountGBP)
+  if (amountUSD != null && !Number.isNaN(Number(amountUSD))) return Number(amountUSD) / gbpUsdRate
+  return 0
+}
+
+const toDateOnly = (value: string): string => value.split('T')[0]
+
+const median = (values: number[]): number => {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+const round = (n: number) => Math.round(n * 100) / 100
+
+const safeDiv = (num: number, den: number, fallback = 0): number => {
+  if (!Number.isFinite(num) || !Number.isFinite(den) || den === 0) return fallback
+  return num / den
+}
+
+const monthIndex = (dateStr: string): { year: number; month: number } => {
+  const d = toDateOnly(dateStr)
+  const [y, m] = d.split('-').map(Number)
+  return { year: y, month: m } // month 1-12
+}
+
+/** Normalize counterparty for fingerprinting: lowercase, trim, strip non-alphanum. */
+const fingerprintCounterparty = (raw: string | null | undefined): string => {
+  if (!raw) return ''
+  return String(raw)
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+// ---------------------------------------------------------------------------
+// Monthly grid construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-category, per-(year-month) total of expense spend in GBP, expressed as POSITIVE values.
+ * Only includes categories not in EXCLUDED_FROM_FORECAST.
+ *
+ * Shape: { [category]: { [`YYYY-MM`]: amountGBP } }
+ */
+export type MonthlyGrid = Record<string, Record<string, number>>
+
+/** Internal: per-category list of transactions for recurring detection. */
+type CategoryTxIndex = Record<string, ForecastTxRow[]>
+
+export function buildMonthlyGrid(
+  rows: ForecastTxRow[],
+  gbpUsdRate: number,
+): { grid: MonthlyGrid; txByCategory: CategoryTxIndex } {
+  const grid: MonthlyGrid = {}
+  const txByCategory: CategoryTxIndex = {}
+  for (const row of rows) {
+    if (!row.category) continue
+    if (EXCLUDED_FROM_FORECAST.has(row.category)) continue
+    const amount = normalizeAmountGBP(row.amount_gbp, row.amount_usd, gbpUsdRate)
+    if (amount === 0) continue
+    // Expenses: only count negative-sign entries for an expense category (treat as positive spend).
+    if (amount > 0) continue // income/refunds in expense category — ignore for forecast
+    const date = toDateOnly(row.date)
+    if (!date) continue
+    const ym = date.slice(0, 7)
+    grid[row.category] ??= {}
+    grid[row.category][ym] = (grid[row.category][ym] ?? 0) + Math.abs(amount)
+    txByCategory[row.category] ??= []
+    txByCategory[row.category].push({ ...row, date })
+  }
+  return { grid, txByCategory }
+}
+
+const ymKey = (year: number, month: number) =>
+  `${year}-${String(month).padStart(2, '0')}`
+
+// ---------------------------------------------------------------------------
+// M1 — Seasonal Average (trailing-3y calendar-month mean)
+// ---------------------------------------------------------------------------
+
+function computeSeasonalMeans(
+  grid: MonthlyGrid,
+  category: string,
+  trainingYears: number[],
+): { means: number[]; observedYears: number } {
+  // Returns length-12 array; index 0 = January.
+  // For training years where the category had ANY activity, missing months count as £0
+  // (legitimate zero — the user didn't spend in that month). Years with no activity at
+  // all are treated as missing to avoid penalizing newly-tracked categories.
+  const means = new Array(12).fill(0)
+  const counts = new Array(12).fill(0)
+  let observedYears = 0
+  for (const y of trainingYears) {
+    let yearHasData = false
+    for (let m = 1; m <= 12; m++) {
+      if (grid[category]?.[ymKey(y, m)] != null) {
+        yearHasData = true
+        break
+      }
+    }
+    if (!yearHasData) continue
+    observedYears += 1
+    for (let m = 1; m <= 12; m++) {
+      means[m - 1] += grid[category]?.[ymKey(y, m)] ?? 0
+      counts[m - 1] += 1
+    }
+  }
+  return {
+    means: means.map((sum, i) => (counts[i] > 0 ? sum / counts[i] : 0)),
+    observedYears,
+  }
+}
+
+function trailing12Mean(
+  grid: MonthlyGrid,
+  category: string,
+  asOfYear: number,
+  asOfMonth: number,
+): number {
+  let sum = 0
+  let n = 0
+  let y = asOfYear
+  let m = asOfMonth - 1 // start with previous full month
+  for (let i = 0; i < 12; i++) {
+    if (m <= 0) {
+      m = 12
+      y -= 1
+    }
+    const v = grid[category]?.[ymKey(y, m)]
+    if (v != null) {
+      sum += v
+      n += 1
+    }
+    m -= 1
+  }
+  return n > 0 ? sum / n : 0
+}
+
+function methodologyM1(
+  grid: MonthlyGrid,
+  year: number,
+  currentMonth: number,
+  monthProgress: number,
+  ytdByCategory: Record<string, number[]>,
+): MethodologyResult {
+  const trainingYears = [year - 3, year - 2, year - 1]
+  const categories = Object.keys(grid).sort((a, b) => a.localeCompare(b))
+  const byCategory: CategoryMonthlyForecast[] = categories.map((category) => {
+    const { means: seasonal, observedYears } = computeSeasonalMeans(grid, category, trainingYears)
+    const fallback = trailing12Mean(grid, category, year, currentMonth)
+    const monthlyEstimate = (idx: number) => (observedYears > 0 ? seasonal[idx] : fallback)
+
+    const months = new Array(12).fill(0)
+    const monthType: ('actual' | 'partial' | 'forecast')[] = new Array(12).fill('forecast')
+    for (let m = 1; m <= 12; m++) {
+      const idx = m - 1
+      if (m < currentMonth) {
+        months[idx] = ytdByCategory[category]?.[idx] ?? 0
+        monthType[idx] = 'actual'
+      } else if (m === currentMonth) {
+        const mtd = ytdByCategory[category]?.[idx] ?? 0
+        const remainder = (1 - monthProgress) * monthlyEstimate(idx)
+        months[idx] = mtd + remainder
+        monthType[idx] = 'partial'
+      } else {
+        months[idx] = monthlyEstimate(idx)
+        monthType[idx] = 'forecast'
+      }
+    }
+    const fullYear = months.reduce((s, v) => s + v, 0)
+    const ytd = months
+      .slice(0, Math.max(0, currentMonth - 1))
+      .reduce((s, v) => s + v, 0)
+    return {
+      category,
+      months,
+      monthType,
+      isActual: monthType.map((t) => t !== 'forecast'),
+      fullYear: round(fullYear),
+      ytd: round(ytd),
+    }
+  })
+  const fullYearTotal = byCategory.reduce((s, c) => s + c.fullYear, 0)
+  const ytdTotal = byCategory.reduce((s, c) => s + c.ytd, 0)
+  return {
+    id: 'm1',
+    label: 'Seasonal Average',
+    description: 'Trailing 3-year average for each calendar month.',
+    byCategory,
+    fullYearTotal: round(fullYearTotal),
+    ytdTotal: round(ytdTotal),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// M2 — Seasonal + Trend
+// ---------------------------------------------------------------------------
+
+const TREND_CLAMP = 0.3 // ±30% YoY growth clamp
+
+function computeAnnualTotal(
+  grid: MonthlyGrid,
+  category: string,
+  year: number,
+): number {
+  let sum = 0
+  for (let m = 1; m <= 12; m++) {
+    sum += grid[category]?.[ymKey(year, m)] ?? 0
+  }
+  return sum
+}
+
+function computeYoYGrowth(grid: MonthlyGrid, category: string, year: number): number {
+  // Geometric mean of YoY ratios across the trailing 3 windows: (y-1/y-2), (y-2/y-3).
+  // If trailing data is sparse, return 0.
+  const ratios: number[] = []
+  for (let i = 1; i < TRAINING_YEARS; i++) {
+    const recent = computeAnnualTotal(grid, category, year - i)
+    const older = computeAnnualTotal(grid, category, year - i - 1)
+    if (older > 0 && recent > 0) ratios.push(recent / older)
+  }
+  if (ratios.length === 0) return 0
+  const log = ratios.reduce((s, r) => s + Math.log(r), 0) / ratios.length
+  const g = Math.exp(log) - 1 // growth rate
+  return Math.max(-TREND_CLAMP, Math.min(TREND_CLAMP, g))
+}
+
+function methodologyM2(
+  grid: MonthlyGrid,
+  year: number,
+  currentMonth: number,
+  monthProgress: number,
+  ytdByCategory: Record<string, number[]>,
+): MethodologyResult {
+  const trainingYears = [year - 3, year - 2, year - 1]
+  const categories = Object.keys(grid).sort((a, b) => a.localeCompare(b))
+
+  const byCategory: CategoryMonthlyForecast[] = categories.map((category) => {
+    const { means: seasonal, observedYears } = computeSeasonalMeans(grid, category, trainingYears)
+    const seasonalSum = seasonal.reduce((s, v) => s + v, 0)
+    // Seasonal index normalized to mean=1 across observed months
+    const seasonalIndex =
+      seasonalSum > 0 ? seasonal.map((v) => safeDiv(v * 12, seasonalSum, 1)) : new Array(12).fill(1)
+
+    const priorYearTotal = computeAnnualTotal(grid, category, year - 1)
+    const growth = computeYoYGrowth(grid, category, year)
+    const projectedAnnual =
+      priorYearTotal > 0 ? priorYearTotal * (1 + growth) : seasonalSum // fallback to M1's annual
+
+    const monthlyProjected = seasonalIndex.map((idx) => (projectedAnnual / 12) * idx)
+
+    const fallback = trailing12Mean(grid, category, year, currentMonth)
+    const monthlyEstimate = (idx: number) =>
+      observedYears > 0 ? monthlyProjected[idx] : fallback
+
+    const months = new Array(12).fill(0)
+    const monthType: ('actual' | 'partial' | 'forecast')[] = new Array(12).fill('forecast')
+    for (let m = 1; m <= 12; m++) {
+      const idx = m - 1
+      if (m < currentMonth) {
+        months[idx] = ytdByCategory[category]?.[idx] ?? 0
+        monthType[idx] = 'actual'
+      } else if (m === currentMonth) {
+        const mtd = ytdByCategory[category]?.[idx] ?? 0
+        const remainder = (1 - monthProgress) * monthlyEstimate(idx)
+        months[idx] = mtd + remainder
+        monthType[idx] = 'partial'
+      } else {
+        months[idx] = monthlyEstimate(idx)
+        monthType[idx] = 'forecast'
+      }
+    }
+    const fullYear = months.reduce((s, v) => s + v, 0)
+    const ytd = months
+      .slice(0, Math.max(0, currentMonth - 1))
+      .reduce((s, v) => s + v, 0)
+    return {
+      category,
+      months,
+      monthType,
+      isActual: monthType.map((t) => t !== 'forecast'),
+      fullYear: round(fullYear),
+      ytd: round(ytd),
+    }
+  })
+  const fullYearTotal = byCategory.reduce((s, c) => s + c.fullYear, 0)
+  const ytdTotal = byCategory.reduce((s, c) => s + c.ytd, 0)
+  return {
+    id: 'm2',
+    label: 'Seasonal + Trend',
+    description:
+      'Seasonal pattern from trailing 3 years scaled by per-category YoY growth (clamped ±30%).',
+    byCategory,
+    fullYearTotal: round(fullYearTotal),
+    ytdTotal: round(ytdTotal),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// M3 — Fixed/Variable Decomposition
+// ---------------------------------------------------------------------------
+
+type RecurringCluster = {
+  fingerprint: string
+  category: string
+  /** Mean monthly amount (GBP positive). */
+  monthlyAmount: number
+  /** Months in trailing 12 it fired in. */
+  monthsActive: number
+  /** Most recent month it appeared in (YYYY-MM). */
+  lastMonth: string
+}
+
+function detectRecurring(
+  txByCategory: CategoryTxIndex,
+  gbpUsdRate: number,
+  asOfYear: number,
+  asOfMonth: number,
+): Record<string, RecurringCluster[]> {
+  const result: Record<string, RecurringCluster[]> = {}
+  // Trailing 12-month cutoff
+  let startY = asOfYear
+  let startM = asOfMonth - 11
+  while (startM <= 0) {
+    startM += 12
+    startY -= 1
+  }
+  const startKey = ymKey(startY, startM)
+
+  for (const [category, txs] of Object.entries(txByCategory)) {
+    // Group by counterparty fingerprint; gate clusters on amount stability (CV).
+    const byFingerprint = new Map<
+      string,
+      { amounts: number[]; months: Set<string>; monthAmount: Map<string, number>; lastMonth: string }
+    >()
+    for (const tx of txs) {
+      const ym = tx.date.slice(0, 7)
+      if (ym < startKey) continue
+      const amt = Math.abs(normalizeAmountGBP(tx.amount_gbp, tx.amount_usd, gbpUsdRate))
+      if (amt === 0) continue
+      const cp = fingerprintCounterparty(tx.counterparty)
+      if (!cp) continue
+      const entry = byFingerprint.get(cp) ?? {
+        amounts: [],
+        months: new Set<string>(),
+        monthAmount: new Map<string, number>(),
+        lastMonth: '',
+      }
+      entry.amounts.push(amt)
+      entry.months.add(ym)
+      entry.monthAmount.set(ym, (entry.monthAmount.get(ym) ?? 0) + amt)
+      if (ym > entry.lastMonth) entry.lastMonth = ym
+      byFingerprint.set(cp, entry)
+    }
+    const clusters: RecurringCluster[] = []
+    for (const [cp, entry] of byFingerprint.entries()) {
+      if (entry.months.size < 9) continue // require 9 of last 12 months
+      // Gate on month-to-month amount stability: coefficient of variation ≤ 0.15.
+      const monthly = Array.from(entry.monthAmount.values())
+      const mean = monthly.reduce((s, v) => s + v, 0) / monthly.length
+      if (mean <= 0) continue
+      const variance =
+        monthly.reduce((s, v) => s + (v - mean) ** 2, 0) / monthly.length
+      const cv = Math.sqrt(variance) / mean
+      if (cv > 0.15) continue
+      clusters.push({
+        fingerprint: cp,
+        category,
+        monthlyAmount: mean,
+        monthsActive: entry.months.size,
+        lastMonth: entry.lastMonth,
+      })
+    }
+    if (clusters.length > 0) result[category] = clusters
+  }
+  return result
+}
+
+function methodologyM3(
+  grid: MonthlyGrid,
+  txByCategory: CategoryTxIndex,
+  year: number,
+  currentMonth: number,
+  monthProgress: number,
+  ytdByCategory: Record<string, number[]>,
+  gbpUsdRate: number,
+): MethodologyResult {
+  const recurringByCategory = detectRecurring(txByCategory, gbpUsdRate, year, currentMonth)
+  const trainingYears = [year - 3, year - 2, year - 1]
+
+  const categories = Object.keys(grid).sort((a, b) => a.localeCompare(b))
+  const byCategory: CategoryMonthlyForecast[] = categories.map((category) => {
+    const fixedMonthly = (recurringByCategory[category] ?? []).reduce(
+      (s, c) => s + c.monthlyAmount,
+      0,
+    )
+    // Compute trailing-12m total for this category and back out fixed.
+    const trailing12Total = (() => {
+      let sum = 0
+      let y = year
+      let m = currentMonth - 1
+      for (let i = 0; i < 12; i++) {
+        if (m <= 0) {
+          m = 12
+          y -= 1
+        }
+        sum += grid[category]?.[ymKey(y, m)] ?? 0
+        m -= 1
+      }
+      return sum
+    })()
+    const fixedTrailing = fixedMonthly * 12
+    const variableTrailing = Math.max(0, trailing12Total - fixedTrailing)
+    const variableMean = variableTrailing / 12
+
+    // Use M1's seasonal pattern (normalized to mean=1) to allocate variable across months.
+    const { means: seasonal } = computeSeasonalMeans(grid, category, trainingYears)
+    const seasonalSum = seasonal.reduce((s, v) => s + v, 0)
+    const seasonalIndex =
+      seasonalSum > 0 ? seasonal.map((v) => safeDiv(v * 12, seasonalSum, 1)) : new Array(12).fill(1)
+
+    const monthlyEstimate = (idx: number) => fixedMonthly + variableMean * seasonalIndex[idx]
+
+    const months = new Array(12).fill(0)
+    const monthType: ('actual' | 'partial' | 'forecast')[] = new Array(12).fill('forecast')
+    for (let m = 1; m <= 12; m++) {
+      const idx = m - 1
+      if (m < currentMonth) {
+        months[idx] = ytdByCategory[category]?.[idx] ?? 0
+        monthType[idx] = 'actual'
+      } else if (m === currentMonth) {
+        const mtd = ytdByCategory[category]?.[idx] ?? 0
+        const remainder = (1 - monthProgress) * monthlyEstimate(idx)
+        months[idx] = mtd + remainder
+        monthType[idx] = 'partial'
+      } else {
+        months[idx] = monthlyEstimate(idx)
+        monthType[idx] = 'forecast'
+      }
+    }
+    const fullYear = months.reduce((s, v) => s + v, 0)
+    const ytd = months
+      .slice(0, Math.max(0, currentMonth - 1))
+      .reduce((s, v) => s + v, 0)
+    return {
+      category,
+      months,
+      monthType,
+      isActual: monthType.map((t) => t !== 'forecast'),
+      fullYear: round(fullYear),
+      ytd: round(ytd),
+    }
+  })
+  const fullYearTotal = byCategory.reduce((s, c) => s + c.fullYear, 0)
+  const ytdTotal = byCategory.reduce((s, c) => s + c.ytd, 0)
+  return {
+    id: 'm3',
+    label: 'Fixed + Variable',
+    description:
+      'Detects recurring fixed spend (counterparty + amount, ≥9 of last 12 months) and projects only the variable portion seasonally.',
+    byCategory,
+    fullYearTotal: round(fullYearTotal),
+    ytdTotal: round(ytdTotal),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// YTD by category (per month)
+// ---------------------------------------------------------------------------
+
+function buildYtdByCategory(
+  grid: MonthlyGrid,
+  year: number,
+  currentMonth: number,
+): Record<string, number[]> {
+  const out: Record<string, number[]> = {}
+  for (const category of Object.keys(grid)) {
+    const arr = new Array(12).fill(0)
+    for (let m = 1; m <= currentMonth; m++) {
+      arr[m - 1] = grid[category]?.[ymKey(year, m)] ?? 0
+    }
+    out[category] = arr
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Ensemble
+// ---------------------------------------------------------------------------
+
+function buildEnsemble(
+  methodologies: MethodologyResult[],
+  grid: MonthlyGrid,
+  year: number,
+  currentMonth: number,
+  monthProgress: number,
+): ForecastEnsemble {
+  // Union of categories across methodologies.
+  const categorySet = new Set<string>()
+  methodologies.forEach((m) => m.byCategory.forEach((c) => categorySet.add(c.category)))
+  const categories = Array.from(categorySet).sort((a, b) => a.localeCompare(b))
+
+  const findCategory = (m: MethodologyResult, cat: string) =>
+    m.byCategory.find((c) => c.category === cat)
+
+  const categoriesOut: EnsembleCategory[] = categories.map((category) => {
+    const m1 = findCategory(methodologies.find((m) => m.id === 'm1')!, category)
+    const m2 = findCategory(methodologies.find((m) => m.id === 'm2')!, category)
+    const m3 = findCategory(methodologies.find((m) => m.id === 'm3')!, category)
+
+    const monthsBase = new Array(12).fill(0)
+    const monthsLow = new Array(12).fill(0)
+    const monthsHigh = new Array(12).fill(0)
+    const monthType: ('actual' | 'partial' | 'forecast')[] = new Array(12).fill('forecast')
+
+    for (let i = 0; i < 12; i++) {
+      const vs = [m1?.months[i] ?? 0, m2?.months[i] ?? 0, m3?.months[i] ?? 0]
+      const t = m1?.monthType[i] ?? 'forecast'
+      monthType[i] = t
+      if (t === 'actual') {
+        monthsBase[i] = vs[0]
+        monthsLow[i] = vs[0]
+        monthsHigh[i] = vs[0]
+      } else {
+        // 'partial' and 'forecast' both have methodology spread.
+        monthsBase[i] = median(vs)
+        monthsLow[i] = Math.min(...vs)
+        monthsHigh[i] = Math.max(...vs)
+      }
+    }
+
+    const fyVs = [m1?.fullYear ?? 0, m2?.fullYear ?? 0, m3?.fullYear ?? 0]
+    const ytd = m1?.ytd ?? 0
+    const priorYearActual = computeAnnualTotal(grid, category, year - 1)
+
+    return {
+      category,
+      ytd: round(ytd),
+      monthsBase: monthsBase.map(round),
+      monthsLow: monthsLow.map(round),
+      monthsHigh: monthsHigh.map(round),
+      monthType,
+      isActual: monthType.map((t) => t !== 'forecast'),
+      byMethodology: { m1: m1?.fullYear ?? 0, m2: m2?.fullYear ?? 0, m3: m3?.fullYear ?? 0 },
+      fullYearLow: round(Math.min(...fyVs)),
+      fullYearBase: round(median(fyVs)),
+      fullYearHigh: round(Math.max(...fyVs)),
+      priorYearActual: round(priorYearActual),
+    }
+  })
+
+  // Aggregate totals — sum *per-month* and sum of full-year low/base/high.
+  const totalsMonthsBase = new Array(12).fill(0)
+  const totalsMonthsLow = new Array(12).fill(0)
+  const totalsMonthsHigh = new Array(12).fill(0)
+  const totalsMonthType: ('actual' | 'partial' | 'forecast')[] = new Array(12).fill('forecast')
+  let totalYtd = 0
+  let totalFyBase = 0
+  let totalFyLow = 0
+  let totalFyHigh = 0
+  let totalPyActual = 0
+  let totalM1 = 0
+  let totalM2 = 0
+  let totalM3 = 0
+
+  for (const c of categoriesOut) {
+    for (let i = 0; i < 12; i++) {
+      totalsMonthsBase[i] += c.monthsBase[i]
+      totalsMonthsLow[i] += c.monthsLow[i]
+      totalsMonthsHigh[i] += c.monthsHigh[i]
+      totalsMonthType[i] = c.monthType[i]
+    }
+    totalYtd += c.ytd
+    totalFyBase += c.fullYearBase
+    totalFyLow += c.fullYearLow
+    totalFyHigh += c.fullYearHigh
+    totalPyActual += c.priorYearActual
+    totalM1 += c.byMethodology.m1
+    totalM2 += c.byMethodology.m2
+    totalM3 += c.byMethodology.m3
+  }
+
+  return {
+    year,
+    currentMonth,
+    currentMonthProgress: monthProgress,
+    categories: categoriesOut,
+    totals: {
+      ytd: round(totalYtd),
+      monthsBase: totalsMonthsBase.map(round),
+      monthsLow: totalsMonthsLow.map(round),
+      monthsHigh: totalsMonthsHigh.map(round),
+      monthType: totalsMonthType,
+      isActual: totalsMonthType.map((t) => t !== 'forecast'),
+      fullYearLow: round(totalFyLow),
+      fullYearBase: round(totalFyBase),
+      fullYearHigh: round(totalFyHigh),
+      priorYearActual: round(totalPyActual),
+      byMethodology: { m1: round(totalM1), m2: round(totalM2), m3: round(totalM3) },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Backtest
+// ---------------------------------------------------------------------------
+
+/**
+ * Backtest re-runs each methodology as if it were 1 January of the most recent completed year,
+ * using ONLY data strictly before that year. Compares full-year forecast to actual full-year spend.
+ */
+function runBacktest(
+  rows: ForecastTxRow[],
+  gbpUsdRate: number,
+  currentYear: number,
+): BacktestResult | null {
+  const backtestYear = currentYear - 1
+  // Keep only rows strictly before the backtest year for training.
+  const trainingRows = rows.filter((r) => toDateOnly(r.date) < `${backtestYear}-01-01`)
+  // Need at least 1 prior year of training data.
+  const earliestTraining = trainingRows.reduce(
+    (min, r) => (toDateOnly(r.date) < min ? toDateOnly(r.date) : min),
+    '9999-12-31',
+  )
+  if (earliestTraining > `${backtestYear - 1}-12-01`) return null
+
+  const { grid: trainingGrid } = buildMonthlyGrid(trainingRows, gbpUsdRate)
+  const trainingTxByCategory: CategoryTxIndex = {}
+  for (const row of trainingRows) {
+    if (!row.category || EXCLUDED_FROM_FORECAST.has(row.category)) continue
+    const amt = normalizeAmountGBP(row.amount_gbp, row.amount_usd, gbpUsdRate)
+    if (amt >= 0) continue
+    trainingTxByCategory[row.category] ??= []
+    trainingTxByCategory[row.category].push({ ...row, date: toDateOnly(row.date) })
+  }
+
+  // Run each methodology with currentMonth = 0 (no YTD), forecasting all 12 months of backtestYear.
+  const ytdByCategory: Record<string, number[]> = {}
+  for (const cat of Object.keys(trainingGrid)) {
+    ytdByCategory[cat] = new Array(12).fill(0)
+  }
+  // currentMonth=0 means no month is current — every month is a clean forecast.
+  const m1 = methodologyM1(trainingGrid, backtestYear, 0, 1, ytdByCategory)
+  const m2 = methodologyM2(trainingGrid, backtestYear, 0, 1, ytdByCategory)
+  const m3 = methodologyM3(trainingGrid, trainingTxByCategory, backtestYear, 0, 1, ytdByCategory, gbpUsdRate)
+
+  // Actuals for backtestYear come from rows IN that year.
+  const actualRows = rows.filter((r) => {
+    const d = toDateOnly(r.date)
+    return d >= `${backtestYear}-01-01` && d < `${backtestYear + 1}-01-01`
+  })
+  const { grid: actualGrid } = buildMonthlyGrid(actualRows, gbpUsdRate)
+  const actualByCategory: Record<string, number> = {}
+  for (const cat of Object.keys(actualGrid)) {
+    actualByCategory[cat] = computeAnnualTotal(actualGrid, cat, backtestYear)
+  }
+
+  const allCats = new Set<string>([
+    ...Object.keys(actualByCategory),
+    ...m1.byCategory.map((c) => c.category),
+  ])
+
+  const cap = (x: number) => Math.min(10, Math.max(0, x)) // cap MAPE entries at 1000%
+
+  const categories: BacktestCategoryEntry[] = Array.from(allCats)
+    .sort((a, b) => a.localeCompare(b))
+    .map((category) => {
+      const actual = actualByCategory[category] ?? 0
+      const v1 = m1.byCategory.find((c) => c.category === category)?.fullYear ?? 0
+      const v2 = m2.byCategory.find((c) => c.category === category)?.fullYear ?? 0
+      const v3 = m3.byCategory.find((c) => c.category === category)?.fullYear ?? 0
+      const mape = (forecast: number) =>
+        actual === 0 ? (forecast === 0 ? 0 : 1) : cap(Math.abs(forecast - actual) / actual)
+      return {
+        category,
+        actual: round(actual),
+        m1: round(v1),
+        m2: round(v2),
+        m3: round(v3),
+        m1Mape: mape(v1),
+        m2Mape: mape(v2),
+        m3Mape: mape(v3),
+      }
+    })
+    .filter((c) => c.actual > 0 || c.m1 + c.m2 + c.m3 > 0)
+
+  const totals = {
+    actual: round(categories.reduce((s, c) => s + c.actual, 0)),
+    m1: round(categories.reduce((s, c) => s + c.m1, 0)),
+    m2: round(categories.reduce((s, c) => s + c.m2, 0)),
+    m3: round(categories.reduce((s, c) => s + c.m3, 0)),
+    m1Mape: 0,
+    m2Mape: 0,
+    m3Mape: 0,
+  }
+  // Weighted MAPE = sum(|forecast-actual|) / sum(actual)
+  const sumAbsErr = (key: 'm1' | 'm2' | 'm3') =>
+    categories.reduce((s, c) => s + Math.abs(c[key] - c.actual), 0)
+  totals.m1Mape = totals.actual > 0 ? sumAbsErr('m1') / totals.actual : 0
+  totals.m2Mape = totals.actual > 0 ? sumAbsErr('m2') / totals.actual : 0
+  totals.m3Mape = totals.actual > 0 ? sumAbsErr('m3') / totals.actual : 0
+
+  let bestOverall: MethodologyId = 'm1'
+  if (totals.m2Mape < totals.m1Mape && totals.m2Mape <= totals.m3Mape) bestOverall = 'm2'
+  else if (totals.m3Mape < totals.m1Mape && totals.m3Mape < totals.m2Mape) bestOverall = 'm3'
+
+  return { year: backtestYear, categories, totals, bestOverall }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/** Fraction of the current month elapsed by `asOf`, in (0, 1]. End of month → 1. */
+function computeMonthProgress(asOf: Date): number {
+  const year = asOf.getFullYear()
+  const month = asOf.getMonth() // 0-indexed
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+  // Day-of-month is 1-indexed; treat the current calendar day as inclusive (so day 1 of a 30-day
+  // month gives 1/30 ≈ 0.033, day 30 gives 1.0).
+  const day = asOf.getDate()
+  return Math.max(0, Math.min(1, day / daysInMonth))
+}
+
+export function computeTransactionForecast(
+  rows: ForecastTxRow[],
+  gbpUsdRate: number,
+  asOf: Date,
+): TransactionForecastResult {
+  const year = asOf.getFullYear()
+  const currentMonth = asOf.getMonth() + 1 // 1-12
+  const monthProgress = computeMonthProgress(asOf)
+  const { grid, txByCategory } = buildMonthlyGrid(rows, gbpUsdRate)
+  const ytdByCategory = buildYtdByCategory(grid, year, currentMonth)
+
+  const m1 = methodologyM1(grid, year, currentMonth, monthProgress, ytdByCategory)
+  const m2 = methodologyM2(grid, year, currentMonth, monthProgress, ytdByCategory)
+  const m3 = methodologyM3(grid, txByCategory, year, currentMonth, monthProgress, ytdByCategory, gbpUsdRate)
+  const methodologies = [m1, m2, m3]
+
+  const ensemble = buildEnsemble(methodologies, grid, year, currentMonth, monthProgress)
+  const backtest = runBacktest(rows, gbpUsdRate, year)
+
+  return {
+    asOf: asOf.toISOString().split('T')[0],
+    year,
+    currentMonth,
+    methodologies,
+    ensemble,
+    backtest,
+  }
+}

--- a/lib/hooks/queries/use-transaction-forecast.ts
+++ b/lib/hooks/queries/use-transaction-forecast.ts
@@ -1,0 +1,21 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/query-keys'
+import type { TransactionForecastResult } from '@/lib/forecast-transaction-based'
+
+export function useTransactionForecast(initialData?: TransactionForecastResult | null) {
+  return useQuery({
+    queryKey: queryKeys.transactionForecast,
+    queryFn: async (): Promise<TransactionForecastResult> => {
+      const res = await fetch('/api/forecast/transaction-based')
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(text || 'Failed to load transaction-based forecast')
+      }
+      return res.json()
+    },
+    initialData: initialData ?? undefined,
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/lib/query-keys.ts
+++ b/lib/query-keys.ts
@@ -17,4 +17,5 @@ export const queryKeys = {
   debt: ['debt'] as const,
   investmentReturns: ['investment-returns'] as const,
   financialHealth: ['financial-health'] as const,
+  transactionForecast: ['transaction-forecast'] as const,
 }


### PR DESCRIPTION
…ologies

Build a /forecast page that forecasts the year's expense spend purely from transaction_log, with no dependence on forecast_settings or budget_targets. Three independent methodologies are computed and surfaced as a low/base/high range (min/median/max across them), giving the user a configuration-free scenario view.

Methodologies (all on trailing 3y, expense categories only — Income, Other Income, Gift Money, Excluded filtered out):

- M1 Seasonal Average: trailing-3y mean per (category, calendar month).
- M2 Seasonal + Trend: M1 seasonal index scaled by per-category YoY growth (geometric mean, clamped to ±30%).
- M3 Fixed + Variable: detect recurring fixed spend by clustering on counterparty fingerprint with coefficient-of-variation gating, then forecast fixed unchanged and variable seasonally.

The current calendar month is treated as MTD actual + (1 - day/days_in_month) × monthly_estimate, so the full-year total naturally folds in partial-month spend rather than dropping or extrapolating it.

Page sections: summary cards (YTD, base, scenario range, vs prior year), month-by-month bar chart with ensemble band, sortable per-category table, click-through drilldown line chart, prior-year backtest panel showing weighted MAPE per methodology, and a methodology notes panel.

Verified:
- npm run build clean.
- Synthetic 4-year smoke test: 48/48 reconciliation, monthType, ensemble band, trend detection, recurring detection, and backtest checks pass.
- Caught and fixed a seasonal-zero bug in M1 along the way (a category that's legitimately £0 in 11 of 12 months was being projected at the trailing-12m mean for every empty month).