### PR TITLE
feat(insights): add ranked top-5 allocation & spending observations

### DIFF
--- a/components/insights/insights-data-block.tsx
+++ b/components/insights/insights-data-block.tsx
@@ -1,5 +1,6 @@
 import type { InsightsDataPayload } from '@/lib/insights-data'
 import { KeyInsights } from './key-insights'
+import { ObservationsSection } from './observations-section'
 
 /**
  * Presentational block for Key Insights heading + preloaded payload.
@@ -14,6 +15,10 @@ export function InsightsDataBlock({ initialData }: { initialData: InsightsDataPa
         </p>
       </div>
       <KeyInsights initialData={initialData} />
+      <ObservationsSection
+        allocation={initialData.allocationObservations ?? []}
+        spending={initialData.spendingObservations ?? []}
+      />
     </>
   )
 }

--- a/components/insights/observation-card.tsx
+++ b/components/insights/observation-card.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { AlertCircle, ChevronDown, ChevronRight, Info, TrendingUp } from 'lucide-react'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { cn } from '@/utils/cn'
+import type { Observation, ObservationSeverity } from '@/lib/observations'
+
+const SEVERITY_TOKENS: Record<
+  ObservationSeverity,
+  { borderClass: string; iconClass: string; pillClass: string; Icon: typeof Info }
+> = {
+  info: {
+    borderClass: 'border-l-blue-500',
+    iconClass: 'text-blue-600 dark:text-blue-400',
+    pillClass: 'bg-blue-500/15 text-blue-700 dark:text-blue-300',
+    Icon: Info,
+  },
+  notable: {
+    borderClass: 'border-l-amber-500',
+    iconClass: 'text-amber-600 dark:text-amber-400',
+    pillClass: 'bg-amber-500/15 text-amber-700 dark:text-amber-300',
+    Icon: TrendingUp,
+  },
+  attention: {
+    borderClass: 'border-l-red-500',
+    iconClass: 'text-red-600 dark:text-red-400',
+    pillClass: 'bg-red-500/15 text-red-700 dark:text-red-300',
+    Icon: AlertCircle,
+  },
+}
+
+function formatMetric(o: Observation): string {
+  const v = o.metric.value
+  if (o.metric.unit === '%') return `${v.toFixed(0)}%`
+  if (o.metric.unit === 'count') return `${Math.round(v)}`
+  if (o.metric.unit === 'days') return `${Math.round(v)}d`
+  return `${v}`
+}
+
+export function ObservationCard({ observation }: { observation: Observation }) {
+  const [expanded, setExpanded] = useState(false)
+  const tokens = SEVERITY_TOKENS[observation.severity]
+  const Icon = tokens.Icon
+
+  return (
+    <Card
+      id={observation.id}
+      className={cn('scroll-mt-24 border-l-[3px]', tokens.borderClass)}
+    >
+      <CardHeader
+        className="cursor-pointer pb-3"
+        onClick={() => setExpanded((v) => !v)}
+        role="button"
+        aria-expanded={expanded}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3 flex-1 min-w-0">
+            <Icon className={cn('h-5 w-5 mt-0.5 shrink-0', tokens.iconClass)} />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 flex-wrap">
+                <h3 className="text-sm md:text-base font-semibold leading-snug">
+                  {observation.title}
+                </h3>
+                <span className={cn('text-xs font-medium px-2 py-0.5 rounded-full', tokens.pillClass)}>
+                  {formatMetric(observation)}
+                </span>
+              </div>
+              <p className="text-xs md:text-sm text-muted-foreground mt-1 leading-snug">
+                {observation.oneLiner}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label={expanded ? 'Collapse details' : 'Expand details'}
+          >
+            {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+          </button>
+        </div>
+      </CardHeader>
+      {expanded && (
+        <CardContent className="pt-0">
+          <div className="border-t pt-3 space-y-2">
+            <div className="text-xs uppercase tracking-wide text-muted-foreground font-medium">
+              Underlying numbers
+            </div>
+            <dl className="space-y-1">
+              {observation.evidence.map((row, i) => (
+                <div
+                  key={`${row.label}-${i}`}
+                  className={cn(
+                    'flex items-center justify-between gap-3 text-sm',
+                    row.subtotal && 'pt-1 mt-1 border-t font-medium'
+                  )}
+                >
+                  <dt className="text-muted-foreground">{row.label}</dt>
+                  <dd className="font-mono tabular-nums">{row.value}</dd>
+                </div>
+              ))}
+            </dl>
+            {observation.drillIn && (
+              <div className="pt-2">
+                <Link
+                  href={observation.drillIn.href}
+                  className="text-xs font-medium text-primary hover:underline inline-flex items-center gap-1"
+                >
+                  {observation.drillIn.label}
+                  <ChevronRight className="h-3 w-3" />
+                </Link>
+              </div>
+            )}
+            <div className="text-[10px] text-muted-foreground pt-1">
+              As of {observation.asOf}
+            </div>
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  )
+}

--- a/components/insights/observations-section.tsx
+++ b/components/insights/observations-section.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/utils/cn'
+import { Wallet, TrendingUp } from 'lucide-react'
+import type { Observation } from '@/lib/observations'
+import { ObservationCard } from './observation-card'
+
+interface ObservationsSectionProps {
+  allocation: Observation[]
+  spending: Observation[]
+}
+
+type Tab = 'allocation' | 'spending'
+
+export function ObservationsSection({ allocation, spending }: ObservationsSectionProps) {
+  const [tab, setTab] = useState<Tab>('allocation')
+  const items = tab === 'allocation' ? allocation : spending
+
+  return (
+    <Card id="observations" className="scroll-mt-24 border-l-[3px] border-l-violet-500">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div>
+            <CardTitle className="text-lg md:text-xl">What your data shows</CardTitle>
+            <p className="text-xs md:text-sm text-muted-foreground mt-1">
+              Top 5 observations from your own data, ranked by magnitude.
+            </p>
+          </div>
+          <div className="inline-flex rounded-lg border bg-muted/40 p-1 text-xs md:text-sm">
+            <button
+              type="button"
+              onClick={() => setTab('allocation')}
+              className={cn(
+                'px-3 py-1.5 rounded-md font-medium inline-flex items-center gap-1.5 transition-colors',
+                tab === 'allocation'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <Wallet className="h-3.5 w-3.5" />
+              Allocation
+            </button>
+            <button
+              type="button"
+              onClick={() => setTab('spending')}
+              className={cn(
+                'px-3 py-1.5 rounded-md font-medium inline-flex items-center gap-1.5 transition-colors',
+                tab === 'spending'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <TrendingUp className="h-3.5 w-3.5" />
+              Spending
+            </button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {items.length === 0 ? (
+          <div className="text-sm text-muted-foreground py-6 text-center">
+            No notable {tab} observations from your data right now.
+          </div>
+        ) : (
+          items.map((o) => <ObservationCard key={o.id} observation={o} />)
+        )}
+        <p className="text-[11px] text-muted-foreground pt-2 leading-relaxed">
+          These are observations from your own data. TS Personal Finance does not provide financial advice.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -9,6 +9,7 @@ import { createGetNetWorthTrendTool } from './get-net-worth-trend'
 import { createAnalyzeMonthlyCategoryTrendsTool } from './analyze-monthly-category-trends'
 import { createGetCashRunwayTool } from './get-cash-runway'
 import { createSearchWebTool } from './search-web'
+import { createSurfaceObservationsTool } from './surface-observations'
 
 export { type ToolContext } from './types'
 
@@ -24,5 +25,6 @@ export function createChatTools(ctx: ToolContext) {
     analyze_monthly_category_trends: createAnalyzeMonthlyCategoryTrendsTool(ctx),
     get_cash_runway: createGetCashRunwayTool(ctx),
     search_web: createSearchWebTool(ctx),
+    surface_observations: createSurfaceObservationsTool(ctx),
   }
 }

--- a/lib/ai/tools/surface-observations.ts
+++ b/lib/ai/tools/surface-observations.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod'
+import type { ToolContext } from './types'
+import { fetchInsightsData } from '@/lib/insights-data'
+
+export function createSurfaceObservationsTool(ctx: ToolContext) {
+  return {
+    description: `Surface the top observations from the user's own financial data — both account allocation patterns (concentration, FX exposure, cash share, stale balances) and spending patterns (YoY spikes, monthly outliers, forecast vs budget). These are descriptive observations of the user's data, NOT financial advice or recommendations. When summarizing, paraphrase the facts; do not add prescriptive language ("you should move X", "consider switching", etc.). Use this when the user asks "what should I focus on?", "what stands out?", "what's notable about my finances?", or similar.`,
+    inputSchema: z.object({
+      kind: z
+        .enum(['allocation', 'spending', 'both'])
+        .optional()
+        .default('both')
+        .describe('Which pool of observations to surface.'),
+      max: z
+        .number()
+        .int()
+        .min(1)
+        .max(10)
+        .optional()
+        .default(5)
+        .describe('Maximum observations per pool (default 5).'),
+    }),
+    execute: async ({
+      kind = 'both',
+      max = 5,
+    }: {
+      kind?: 'allocation' | 'spending' | 'both'
+      max?: number
+    }) => {
+      try {
+        const payload = await fetchInsightsData(ctx.supabase, ctx.userId)
+
+        const project = (
+          obs: typeof payload.allocationObservations
+        ) =>
+          obs.slice(0, max).map((o) => ({
+            id: o.id,
+            kind: o.kind,
+            severity: o.severity,
+            title: o.title,
+            oneLiner: o.oneLiner,
+            metric: o.metric,
+            evidence: o.evidence,
+            asOf: o.asOf,
+            drillIn: o.drillIn,
+          }))
+
+        const result: {
+          allocation?: ReturnType<typeof project>
+          spending?: ReturnType<typeof project>
+          summary: string
+          asOf: string
+        } = {
+          asOf: ctx.todayISO,
+          summary: '',
+        }
+
+        if (kind === 'allocation' || kind === 'both') {
+          result.allocation = project(payload.allocationObservations ?? [])
+        }
+        if (kind === 'spending' || kind === 'both') {
+          result.spending = project(payload.spendingObservations ?? [])
+        }
+
+        const allocCount = result.allocation?.length ?? 0
+        const spendCount = result.spending?.length ?? 0
+        result.summary = `Surfaced ${allocCount} allocation observation${allocCount === 1 ? '' : 's'} and ${spendCount} spending observation${spendCount === 1 ? '' : 's'} from the user's data. Paraphrase descriptively; do not add prescriptive recommendations.`
+
+        return result
+      } catch (err) {
+        console.error('[chat] surface_observations: Execution error', err)
+        return { error: err instanceof Error ? err.message : 'Unknown error' }
+      }
+    },
+  }
+}

--- a/lib/insights-data.ts
+++ b/lib/insights-data.ts
@@ -8,7 +8,19 @@ import {
   fetchCategories,
   fetchTransactionsPaged,
 } from '@/lib/forecasting'
-import type { BudgetTarget, AnnualTrend, MonthlyTrend, HistoricalNetWorth, AccountBalance } from '@/lib/types'
+import type {
+  BudgetTarget,
+  AnnualTrend,
+  MonthlyTrend,
+  HistoricalNetWorth,
+  AccountBalance,
+  RecurringPayment,
+} from '@/lib/types'
+import {
+  rankAllocationObservations,
+  rankSpendingObservations,
+  type Observation,
+} from '@/lib/observations'
 
 export interface ForecastByCategoryItem {
   category: string
@@ -25,6 +37,8 @@ export interface InsightsDataPayload {
   forecastByCategory: ForecastByCategoryItem[]
   historicalNetWorth: HistoricalNetWorth[]
   accountBalances: AccountBalance[]
+  allocationObservations: Observation[]
+  spendingObservations: Observation[]
   error: string | null
 }
 
@@ -46,6 +60,7 @@ export async function fetchInsightsData(
     budgetResult,
     netWorthResult,
     accountsResult,
+    recurringResult,
     rate,
     settingsMap,
     categories,
@@ -63,6 +78,7 @@ export async function fetchInsightsData(
       .select('*')
       .order('date_updated', { ascending: false })
       .limit(500),
+    supabase.from('recurring_payments').select('*').eq('user_id', userId),
     fetchFxRateGBPUSD(supabase),
     fetchForecastSettingsMap(supabase, userId),
     fetchCategories(supabase, userId),
@@ -109,6 +125,21 @@ export async function fetchInsightsData(
       }))
     : []
 
+  const recurring = (recurringResult.data ?? []) as RecurringPayment[]
+  const asOf = new Date().toISOString().slice(0, 10)
+  const observationsInput = {
+    accounts: accountBalances,
+    recurring,
+    annualTrends: annualTrends ?? [],
+    monthlyTrends: monthlyTrends ?? [],
+    forecastByCategory: forecastByCategorySerialized,
+    gbpUsdRate: rate || 1.25,
+    baseCurrency: 'GBP' as const,
+    asOf,
+  }
+  const allocationObservations = rankAllocationObservations(observationsInput, 5)
+  const spendingObservations = rankSpendingObservations(observationsInput, 5)
+
   return {
     budgetData: budgetResult.data ?? [],
     annualTrends: annualTrends ?? [],
@@ -116,6 +147,8 @@ export async function fetchInsightsData(
     forecastByCategory: forecastByCategorySerialized,
     historicalNetWorth: netWorthResult.data ?? [],
     accountBalances,
+    allocationObservations,
+    spendingObservations,
     error: budgetResult.error || netWorthResult.error || accountsResult.error ? 'Partial failure' : null,
   }
 }

--- a/lib/observations.ts
+++ b/lib/observations.ts
@@ -1,0 +1,682 @@
+import type {
+  AccountBalance,
+  AnnualTrend,
+  MonthlyTrend,
+  RecurringPayment,
+} from '@/lib/types'
+import type { ForecastByCategoryItem } from '@/lib/insights-data'
+
+export type ObservationKind = 'allocation' | 'spending'
+export type ObservationSeverity = 'info' | 'notable' | 'attention'
+export type ObservationUnit = '%' | 'GBP' | 'USD' | 'days' | 'count'
+
+export interface ObservationMetric {
+  label: string
+  value: number
+  unit: ObservationUnit
+}
+
+export interface ObservationEvidenceRow {
+  label: string
+  value: number | string
+  subtotal?: boolean
+}
+
+export interface Observation {
+  id: string
+  kind: ObservationKind
+  detector: string
+  severity: ObservationSeverity
+  title: string
+  oneLiner: string
+  metric: ObservationMetric
+  evidence: ObservationEvidenceRow[]
+  comparators?: { vsLastYear?: number; vsBudget?: number; zScore?: number }
+  baseCurrency: 'GBP' | 'USD'
+  asOf: string
+  drillIn?: { href: string; label: string }
+  rankScore: number
+}
+
+export interface ObservationsInput {
+  accounts: AccountBalance[]
+  recurring: RecurringPayment[]
+  annualTrends: AnnualTrend[]
+  monthlyTrends: MonthlyTrend[]
+  forecastByCategory: ForecastByCategoryItem[]
+  gbpUsdRate: number
+  baseCurrency: 'GBP' | 'USD'
+  asOf: string
+}
+
+const EXPENSE_EXCLUDED_CATEGORIES = new Set([
+  'Income',
+  'Gift Money',
+  'Other Income',
+  'Excluded',
+])
+
+const STALE_DAYS = 60
+const NOISE_FLOOR_GBP = 500
+const CONCENTRATION_TOP1_THRESHOLD = 0.25
+const CONCENTRATION_TOP3_THRESHOLD = 0.6
+const CASH_LOW_YIELD_THRESHOLD = 0.2
+const FX_EXPOSURE_THRESHOLD = 0.15
+const YOY_SPIKE_THRESHOLD = 0.25
+const Z_SCORE_THRESHOLD = 2
+const FORECAST_OVER_BUDGET_THRESHOLD = 1.1
+
+const LIQUID_CATEGORIES = new Set([
+  'Cash',
+  'Checking',
+  'Savings',
+  'Brokerage',
+  'Retirement',
+  'Alt Inv',
+])
+const LOW_YIELD_CATEGORIES = new Set(['Cash', 'Checking'])
+
+const BANLIST_REGEX = /\b(move|switch|consider|should|recommend(?:ed|s)?|buy|sell|invest in|cut|reduce|trim|increase|decrease|allocate|reallocate)\b/i
+
+function convertToGbp(amountLocal: number, currency: string, rate: number): number {
+  if (currency === 'GBP') return amountLocal
+  if (currency === 'USD') return rate > 0 ? amountLocal / rate : amountLocal
+  if (currency === 'EUR') {
+    const usd = amountLocal * 1.08
+    return rate > 0 ? usd / rate : usd
+  }
+  return amountLocal
+}
+
+function convertGbpToBase(amountGbp: number, baseCurrency: 'GBP' | 'USD', rate: number): number {
+  if (baseCurrency === 'GBP') return amountGbp
+  return amountGbp * rate
+}
+
+function formatCurrency(amount: number, currency: 'GBP' | 'USD'): string {
+  const symbol = currency === 'GBP' ? '£' : '$'
+  return `${symbol}${Math.abs(amount).toLocaleString('en-US', { maximumFractionDigits: 0 })}${amount < 0 ? ' (cr)' : ''}`
+}
+
+function daysSince(dateISO: string, asOfISO: string): number {
+  const a = new Date(dateISO).getTime()
+  const b = new Date(asOfISO).getTime()
+  if (Number.isNaN(a) || Number.isNaN(b)) return 0
+  return Math.max(0, Math.round((b - a) / (1000 * 60 * 60 * 24)))
+}
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 0
+  return Math.max(0, Math.min(1, v))
+}
+
+interface DetectorMeta {
+  /** Higher priority breaks ties when scores are equal. */
+  priority: number
+}
+
+const DETECTOR_META: Record<string, DetectorMeta> = {
+  'top-account-concentration': { priority: 9 },
+  'cash-low-yield': { priority: 8 },
+  'fx-exposure': { priority: 7 },
+  'stale-balances': { priority: 5 },
+  'recurring-review-backlog': { priority: 4 },
+  'yoy-category-spike': { priority: 9 },
+  'monthly-outlier': { priority: 8 },
+  'forecast-over-budget': { priority: 7 },
+  'recurring-run-rate': { priority: 5 },
+}
+
+const SEVERITY_WEIGHT: Record<ObservationSeverity, number> = {
+  info: 1,
+  notable: 3,
+  attention: 6,
+}
+
+function dedupeAccounts(accounts: AccountBalance[]): AccountBalance[] {
+  const map = new Map<string, AccountBalance>()
+  for (const acc of accounts) {
+    const key = `${acc.institution ?? ''}-${acc.account_name ?? ''}`
+    const existing = map.get(key)
+    if (
+      !existing ||
+      (acc.date_updated && (!existing.date_updated || new Date(acc.date_updated) > new Date(existing.date_updated)))
+    ) {
+      map.set(key, acc)
+    }
+  }
+  return Array.from(map.values())
+}
+
+function detectTopAccountConcentration(input: ObservationsInput): Observation[] {
+  const accounts = dedupeAccounts(input.accounts)
+  const valued = accounts
+    .map((acc) => {
+      const gbp = convertToGbp(acc.balance_total_local ?? 0, acc.currency, input.gbpUsdRate)
+      return {
+        gbp,
+        base: convertGbpToBase(gbp, input.baseCurrency, input.gbpUsdRate),
+        institution: acc.institution,
+        account_name: acc.account_name,
+        category: acc.category,
+      }
+    })
+    .filter((a) => a.gbp > 0)
+    .sort((a, b) => b.gbp - a.gbp)
+
+  const totalAssetsGbp = valued.reduce((s, a) => s + a.gbp, 0)
+  if (totalAssetsGbp <= 0 || valued.length === 0) return []
+
+  const out: Observation[] = []
+  const top1 = valued[0]
+  const top1Pct = top1.gbp / totalAssetsGbp
+
+  if (top1Pct >= CONCENTRATION_TOP1_THRESHOLD) {
+    const severity: ObservationSeverity =
+      top1Pct >= 0.5 ? 'attention' : top1Pct >= 0.35 ? 'notable' : 'info'
+    out.push({
+      id: 'allocation.top-account-concentration',
+      kind: 'allocation',
+      detector: 'top-account-concentration',
+      severity,
+      title: `${(top1Pct * 100).toFixed(0)}% of assets in one account`,
+      oneLiner: `${top1.institution} · ${top1.account_name} holds ${formatCurrency(top1.base, input.baseCurrency)} of your ${formatCurrency(convertGbpToBase(totalAssetsGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency)} total assets.`,
+      metric: { label: 'Top-1 account share', value: top1Pct * 100, unit: '%' },
+      evidence: [
+        { label: `${top1.institution} · ${top1.account_name}`, value: formatCurrency(top1.base, input.baseCurrency) },
+        { label: 'Total assets', value: formatCurrency(convertGbpToBase(totalAssetsGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency), subtotal: true },
+      ],
+      baseCurrency: input.baseCurrency,
+      asOf: input.asOf,
+      drillIn: { href: '/accounts', label: 'View accounts' },
+      rankScore: 0,
+    })
+  }
+
+  if (valued.length >= 3) {
+    const top3 = valued.slice(0, 3)
+    const top3Sum = top3.reduce((s, a) => s + a.gbp, 0)
+    const top3Pct = top3Sum / totalAssetsGbp
+    if (top3Pct >= CONCENTRATION_TOP3_THRESHOLD && top1Pct < 0.5) {
+      const severity: ObservationSeverity = top3Pct >= 0.8 ? 'notable' : 'info'
+      out.push({
+        id: 'allocation.top3-account-concentration',
+        kind: 'allocation',
+        detector: 'top-account-concentration',
+        severity,
+        title: `${(top3Pct * 100).toFixed(0)}% of assets in top 3 accounts`,
+        oneLiner: `Three accounts at ${top3.map((a) => a.institution).join(', ')} hold ${(top3Pct * 100).toFixed(0)}% of your total assets.`,
+        metric: { label: 'Top-3 account share', value: top3Pct * 100, unit: '%' },
+        evidence: [
+          ...top3.map((a) => ({
+            label: `${a.institution} · ${a.account_name}`,
+            value: formatCurrency(convertGbpToBase(a.gbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency),
+          })),
+          { label: 'Top-3 subtotal', value: formatCurrency(convertGbpToBase(top3Sum, input.baseCurrency, input.gbpUsdRate), input.baseCurrency), subtotal: true },
+          { label: 'Total assets', value: formatCurrency(convertGbpToBase(totalAssetsGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency), subtotal: true },
+        ],
+        baseCurrency: input.baseCurrency,
+        asOf: input.asOf,
+        drillIn: { href: '/accounts', label: 'View accounts' },
+        rankScore: 0,
+      })
+    }
+  }
+
+  return out
+}
+
+function detectCashLowYield(input: ObservationsInput): Observation[] {
+  const accounts = dedupeAccounts(input.accounts)
+  const liquid = accounts.filter((a) => LIQUID_CATEGORIES.has(a.category))
+  const totalLiquidGbp = liquid.reduce(
+    (s, a) => s + convertToGbp(a.balance_total_local ?? 0, a.currency, input.gbpUsdRate),
+    0
+  )
+  if (totalLiquidGbp <= 0) return []
+
+  const lowYieldAccounts = liquid.filter((a) => LOW_YIELD_CATEGORIES.has(a.category))
+  const lowYieldGbp = lowYieldAccounts.reduce(
+    (s, a) => s + convertToGbp(a.balance_total_local ?? 0, a.currency, input.gbpUsdRate),
+    0
+  )
+  const pct = lowYieldGbp / totalLiquidGbp
+  if (pct < CASH_LOW_YIELD_THRESHOLD) return []
+
+  const severity: ObservationSeverity = pct >= 0.5 ? 'attention' : pct >= 0.3 ? 'notable' : 'info'
+  return [
+    {
+      id: 'allocation.cash-low-yield',
+      kind: 'allocation',
+      detector: 'cash-low-yield',
+      severity,
+      title: `${(pct * 100).toFixed(0)}% of liquid assets in Cash/Checking`,
+      oneLiner: `${formatCurrency(convertGbpToBase(lowYieldGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency)} of ${formatCurrency(convertGbpToBase(totalLiquidGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency)} liquid sits in Cash or Checking categories as of ${input.asOf}.`,
+      metric: { label: 'Cash share of liquid', value: pct * 100, unit: '%' },
+      evidence: [
+        ...lowYieldAccounts
+          .map((a) => {
+            const gbp = convertToGbp(a.balance_total_local ?? 0, a.currency, input.gbpUsdRate)
+            return {
+              label: `${a.institution} · ${a.account_name} (${a.category})`,
+              value: formatCurrency(convertGbpToBase(gbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency),
+              gbp,
+            }
+          })
+          .sort((a, b) => b.gbp - a.gbp)
+          .map(({ gbp: _gbp, ...row }) => row),
+        { label: 'Cash/Checking subtotal', value: formatCurrency(convertGbpToBase(lowYieldGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency), subtotal: true },
+        { label: 'Total liquid', value: formatCurrency(convertGbpToBase(totalLiquidGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency), subtotal: true },
+      ],
+      baseCurrency: input.baseCurrency,
+      asOf: input.asOf,
+      drillIn: { href: '/liquidity', label: 'View liquidity' },
+      rankScore: 0,
+    },
+  ]
+}
+
+function detectFxExposure(input: ObservationsInput): Observation[] {
+  const accounts = dedupeAccounts(input.accounts)
+  const liquid = accounts.filter((a) => LIQUID_CATEGORIES.has(a.category))
+  const totalLiquidGbp = liquid.reduce(
+    (s, a) => s + convertToGbp(a.balance_total_local ?? 0, a.currency, input.gbpUsdRate),
+    0
+  )
+  if (totalLiquidGbp <= 0) return []
+
+  const nonBase = liquid.filter((a) => a.currency !== input.baseCurrency)
+  const nonBaseGbp = nonBase.reduce(
+    (s, a) => s + convertToGbp(a.balance_total_local ?? 0, a.currency, input.gbpUsdRate),
+    0
+  )
+  const pct = nonBaseGbp / totalLiquidGbp
+  if (pct < FX_EXPOSURE_THRESHOLD) return []
+
+  const byCurrency = nonBase.reduce<Record<string, number>>((acc, a) => {
+    const gbp = convertToGbp(a.balance_total_local ?? 0, a.currency, input.gbpUsdRate)
+    acc[a.currency] = (acc[a.currency] ?? 0) + gbp
+    return acc
+  }, {})
+
+  const severity: ObservationSeverity = pct >= 0.5 ? 'notable' : 'info'
+  return [
+    {
+      id: 'allocation.fx-exposure',
+      kind: 'allocation',
+      detector: 'fx-exposure',
+      severity,
+      title: `${(pct * 100).toFixed(0)}% of liquid assets in non-${input.baseCurrency} currencies`,
+      oneLiner: `${formatCurrency(convertGbpToBase(nonBaseGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency)} of liquid net worth is held in currencies other than ${input.baseCurrency}.`,
+      metric: { label: 'Non-base FX share', value: pct * 100, unit: '%' },
+      evidence: [
+        ...Object.entries(byCurrency)
+          .sort(([, a], [, b]) => b - a)
+          .map(([ccy, gbp]) => ({
+            label: `${ccy} liquid`,
+            value: formatCurrency(convertGbpToBase(gbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency),
+          })),
+        { label: 'Total liquid', value: formatCurrency(convertGbpToBase(totalLiquidGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency), subtotal: true },
+      ],
+      baseCurrency: input.baseCurrency,
+      asOf: input.asOf,
+      drillIn: { href: '/liquidity', label: 'View liquidity' },
+      rankScore: 0,
+    },
+  ]
+}
+
+function detectStaleBalances(input: ObservationsInput): Observation[] {
+  const accounts = dedupeAccounts(input.accounts)
+  const stale = accounts.filter(
+    (a) => a.date_updated && daysSince(a.date_updated, input.asOf) > STALE_DAYS
+  )
+  if (stale.length === 0) return []
+
+  const totalStaleGbp = stale.reduce(
+    (s, a) => s + convertToGbp(Math.abs(a.balance_total_local ?? 0), a.currency, input.gbpUsdRate),
+    0
+  )
+  if (totalStaleGbp < NOISE_FLOOR_GBP) return []
+
+  const oldest = stale.reduce((max, a) => {
+    const days = daysSince(a.date_updated, input.asOf)
+    return days > max ? days : max
+  }, 0)
+
+  const severity: ObservationSeverity = oldest > 180 ? 'notable' : 'info'
+  return [
+    {
+      id: 'allocation.stale-balances',
+      kind: 'allocation',
+      detector: 'stale-balances',
+      severity,
+      title: `${stale.length} account${stale.length === 1 ? '' : 's'} not updated in over ${STALE_DAYS} days`,
+      oneLiner: `${formatCurrency(convertGbpToBase(totalStaleGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency)} sits in accounts whose last update is ${oldest}+ days old as of ${input.asOf}.`,
+      metric: { label: 'Stale accounts', value: stale.length, unit: 'count' },
+      evidence: stale
+        .map((a) => ({
+          label: `${a.institution} · ${a.account_name}`,
+          value: `${daysSince(a.date_updated, input.asOf)} days · ${formatCurrency(convertGbpToBase(convertToGbp(a.balance_total_local ?? 0, a.currency, input.gbpUsdRate), input.baseCurrency, input.gbpUsdRate), input.baseCurrency)}`,
+          days: daysSince(a.date_updated, input.asOf),
+        }))
+        .sort((a, b) => b.days - a.days)
+        .map(({ days: _days, ...row }) => row),
+      baseCurrency: input.baseCurrency,
+      asOf: input.asOf,
+      drillIn: { href: '/accounts', label: 'View accounts' },
+      rankScore: 0,
+    },
+  ]
+}
+
+function detectRecurringReviewBacklog(input: ObservationsInput): Observation[] {
+  const flagged = input.recurring.filter((r) => r.needs_review)
+  if (flagged.length === 0) return []
+
+  const totalAnnualGbp = flagged.reduce((s, r) => s + (r.annualized_amount_gbp ?? 0), 0)
+  if (totalAnnualGbp < NOISE_FLOOR_GBP) return []
+
+  const severity: ObservationSeverity =
+    flagged.length >= 10 ? 'notable' : 'info'
+
+  return [
+    {
+      id: 'allocation.recurring-review-backlog',
+      kind: 'allocation',
+      detector: 'recurring-review-backlog',
+      severity,
+      title: `${flagged.length} recurring charges flagged for review`,
+      oneLiner: `${flagged.length} recurring payments totalling ${formatCurrency(convertGbpToBase(totalAnnualGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency)}/yr are flagged in your data.`,
+      metric: { label: 'Flagged recurring', value: flagged.length, unit: 'count' },
+      evidence: [
+        ...flagged
+          .slice()
+          .sort((a, b) => (b.annualized_amount_gbp ?? 0) - (a.annualized_amount_gbp ?? 0))
+          .slice(0, 8)
+          .map((r) => ({
+            label: r.name,
+            value: formatCurrency(convertGbpToBase(r.annualized_amount_gbp ?? 0, input.baseCurrency, input.gbpUsdRate), input.baseCurrency) + '/yr',
+          })),
+        { label: 'Total flagged annualized', value: formatCurrency(convertGbpToBase(totalAnnualGbp, input.baseCurrency, input.gbpUsdRate), input.baseCurrency) + '/yr', subtotal: true },
+      ],
+      baseCurrency: input.baseCurrency,
+      asOf: input.asOf,
+      drillIn: { href: '/recurring', label: 'View recurring' },
+      rankScore: 0,
+    },
+  ]
+}
+
+function detectYoyCategorySpike(input: ObservationsInput): Observation[] {
+  const candidates = input.annualTrends
+    .filter((t) => !EXPENSE_EXCLUDED_CATEGORIES.has(t.category))
+    .map((t) => {
+      const lastYear = t.cur_yr_minus_1 ?? 0
+      const thisYearEst = t.cur_yr_est ?? 0
+      const absDelta = Math.abs(thisYearEst) - Math.abs(lastYear)
+      const pct = Math.abs(lastYear) > 0 ? absDelta / Math.abs(lastYear) : 0
+      return { category: t.category, lastYear, thisYearEst, absDelta, pct }
+    })
+    .filter((c) => c.pct >= YOY_SPIKE_THRESHOLD && Math.abs(c.absDelta) >= NOISE_FLOOR_GBP)
+    .sort((a, b) => b.absDelta - a.absDelta)
+
+  if (candidates.length === 0) return []
+  const top = candidates[0]
+  const severity: ObservationSeverity =
+    top.pct >= 0.5 ? 'attention' : top.pct >= 0.35 ? 'notable' : 'info'
+
+  const formatYr = (v: number) =>
+    formatCurrency(convertGbpToBase(Math.abs(v), input.baseCurrency, input.gbpUsdRate), input.baseCurrency)
+
+  return [
+    {
+      id: `spending.yoy-spike.${slug(top.category)}`,
+      kind: 'spending',
+      detector: 'yoy-category-spike',
+      severity,
+      title: `${top.category} running ${(top.pct * 100).toFixed(0)}% above last year`,
+      oneLiner: `${top.category} is tracking at ${formatYr(top.thisYearEst)} this year vs ${formatYr(top.lastYear)} last year (full-year estimate).`,
+      metric: { label: 'YoY change', value: top.pct * 100, unit: '%' },
+      evidence: candidates.slice(0, 5).map((c) => ({
+        label: c.category,
+        value: `${formatYr(c.lastYear)} → ${formatYr(c.thisYearEst)} (+${(c.pct * 100).toFixed(0)}%)`,
+      })),
+      comparators: { vsLastYear: top.pct },
+      baseCurrency: input.baseCurrency,
+      asOf: input.asOf,
+      drillIn: { href: `/analysis?section=transactions&category=${encodeURIComponent(top.category)}`, label: 'View transactions' },
+      rankScore: 0,
+    },
+  ]
+}
+
+function detectMonthlyOutlier(input: ObservationsInput): Observation[] {
+  const candidates = input.monthlyTrends
+    .filter((t) => !EXPENSE_EXCLUDED_CATEGORIES.has(t.category))
+    .filter((t) => Math.abs(t.z_score ?? 0) >= Z_SCORE_THRESHOLD)
+    .filter((t) => Math.abs(t.cur_month_est ?? 0) >= NOISE_FLOOR_GBP / 4)
+    .sort((a, b) => Math.abs(b.z_score ?? 0) - Math.abs(a.z_score ?? 0))
+
+  if (candidates.length === 0) return []
+  const top = candidates[0]
+  const z = top.z_score ?? 0
+  const direction = z > 0 ? 'above' : 'below'
+  const severity: ObservationSeverity =
+    Math.abs(z) >= 3 ? 'attention' : Math.abs(z) >= 2.5 ? 'notable' : 'info'
+
+  const formatBase = (v: number) =>
+    formatCurrency(convertGbpToBase(Math.abs(v), input.baseCurrency, input.gbpUsdRate), input.baseCurrency)
+
+  return [
+    {
+      id: `spending.monthly-outlier.${slug(top.category)}`,
+      kind: 'spending',
+      detector: 'monthly-outlier',
+      severity,
+      title: `${top.category} this month is an outlier (${z >= 0 ? '+' : ''}${z.toFixed(1)}σ)`,
+      oneLiner: `${top.category} is tracking at ${formatBase(top.cur_month_est)} this month, ${direction} the typical monthly range.`,
+      metric: { label: 'z-score', value: Math.abs(z), unit: 'count' },
+      evidence: [
+        { label: 'This month estimate', value: formatBase(top.cur_month_est) },
+        { label: 'TTM monthly avg', value: formatBase(top.ttm_avg) },
+        { label: 'Last 3 months avg', value: formatBase(((top.cur_month_minus_1 ?? 0) + (top.cur_month_minus_2 ?? 0) + (top.cur_month_minus_3 ?? 0)) / 3) },
+        { label: 'z-score', value: `${z >= 0 ? '+' : ''}${z.toFixed(2)}` },
+      ],
+      comparators: { zScore: z },
+      baseCurrency: input.baseCurrency,
+      asOf: input.asOf,
+      drillIn: { href: `/analysis?section=monthly-trends&category=${encodeURIComponent(top.category)}`, label: 'View monthly trends' },
+      rankScore: 0,
+    },
+  ]
+}
+
+function detectForecastVsBudgetGap(input: ObservationsInput): Observation[] {
+  const candidates = input.forecastByCategory
+    .filter((f) => !EXPENSE_EXCLUDED_CATEGORIES.has(f.category))
+    .filter((f) => Math.abs(f.annualBudget) >= NOISE_FLOOR_GBP)
+    .map((f) => {
+      const ratio = Math.abs(f.annualBudget) > 0 ? Math.abs(f.forecast) / Math.abs(f.annualBudget) : 0
+      const overBy = Math.abs(f.forecast) - Math.abs(f.annualBudget)
+      return { ...f, ratio, overBy }
+    })
+    .filter((f) => f.ratio >= FORECAST_OVER_BUDGET_THRESHOLD && f.overBy >= NOISE_FLOOR_GBP)
+    .sort((a, b) => b.overBy - a.overBy)
+
+  if (candidates.length === 0) return []
+  const top = candidates[0]
+  const severity: ObservationSeverity =
+    top.ratio >= 1.5 ? 'attention' : top.ratio >= 1.25 ? 'notable' : 'info'
+
+  const formatBase = (v: number) =>
+    formatCurrency(convertGbpToBase(Math.abs(v), input.baseCurrency, input.gbpUsdRate), input.baseCurrency)
+
+  return [
+    {
+      id: `spending.forecast-over-budget.${slug(top.category)}`,
+      kind: 'spending',
+      detector: 'forecast-over-budget',
+      severity,
+      title: `${top.category} forecast at ${(top.ratio * 100).toFixed(0)}% of budget`,
+      oneLiner: `${top.category} is on track for ${formatBase(top.forecast)} this year vs a ${formatBase(top.annualBudget)} budget.`,
+      metric: { label: 'Forecast vs budget', value: top.ratio * 100, unit: '%' },
+      evidence: candidates.slice(0, 5).map((c) => ({
+        label: c.category,
+        value: `${formatBase(c.forecast)} forecast vs ${formatBase(c.annualBudget)} budget (+${formatBase(c.overBy)})`,
+      })),
+      comparators: { vsBudget: top.ratio },
+      baseCurrency: input.baseCurrency,
+      asOf: input.asOf,
+      drillIn: { href: `/analysis?section=transactions&category=${encodeURIComponent(top.category)}`, label: 'View category' },
+      rankScore: 0,
+    },
+  ]
+}
+
+function detectRecurringRunRate(input: ObservationsInput): Observation[] {
+  const totalRecurringGbp = input.recurring.reduce(
+    (s, r) => s + Math.abs(r.annualized_amount_gbp ?? 0),
+    0
+  )
+  if (totalRecurringGbp < NOISE_FLOOR_GBP) return []
+
+  const totalAnnualSpendGbp = input.annualTrends
+    .filter((t) => !EXPENSE_EXCLUDED_CATEGORIES.has(t.category))
+    .reduce((s, t) => s + Math.abs(t.cur_yr_est ?? 0), 0)
+  if (totalAnnualSpendGbp <= 0) return []
+
+  const pct = totalRecurringGbp / totalAnnualSpendGbp
+  if (pct < 0.15) return []
+
+  const severity: ObservationSeverity = pct >= 0.4 ? 'notable' : 'info'
+  const formatBase = (v: number) =>
+    formatCurrency(convertGbpToBase(v, input.baseCurrency, input.gbpUsdRate), input.baseCurrency)
+
+  const top = input.recurring
+    .slice()
+    .sort((a, b) => Math.abs(b.annualized_amount_gbp ?? 0) - Math.abs(a.annualized_amount_gbp ?? 0))
+    .slice(0, 6)
+
+  return [
+    {
+      id: 'spending.recurring-run-rate',
+      kind: 'spending',
+      detector: 'recurring-run-rate',
+      severity,
+      title: `${(pct * 100).toFixed(0)}% of annual spend is recurring`,
+      oneLiner: `Recurring charges total ${formatBase(totalRecurringGbp)}/yr — ${(pct * 100).toFixed(0)}% of your forecast annual spend of ${formatBase(totalAnnualSpendGbp)}.`,
+      metric: { label: 'Recurring share', value: pct * 100, unit: '%' },
+      evidence: [
+        ...top.map((r) => ({
+          label: r.name,
+          value: formatBase(Math.abs(r.annualized_amount_gbp ?? 0)) + '/yr',
+        })),
+        { label: 'Total recurring annualized', value: formatBase(totalRecurringGbp) + '/yr', subtotal: true },
+        { label: 'Total annual spend (est.)', value: formatBase(totalAnnualSpendGbp), subtotal: true },
+      ],
+      baseCurrency: input.baseCurrency,
+      asOf: input.asOf,
+      drillIn: { href: '/recurring', label: 'View recurring' },
+      rankScore: 0,
+    },
+  ]
+}
+
+function slug(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}
+
+function score(o: Observation): number {
+  const meta = DETECTOR_META[o.detector] ?? { priority: 0 }
+  let magnitudeNorm = 0
+  if (o.metric.unit === '%') magnitudeNorm = clamp01(Math.abs(o.metric.value) / 50)
+  else if (o.comparators?.zScore !== undefined) magnitudeNorm = clamp01(Math.abs(o.comparators.zScore) / 3)
+  else if (o.metric.unit === 'count') magnitudeNorm = clamp01(o.metric.value / 20)
+  else magnitudeNorm = 0.3
+
+  const recencyBoost = daysSince(o.asOf, new Date().toISOString().slice(0, 10)) <= 7 ? 0.5 : 0
+  return (
+    SEVERITY_WEIGHT[o.severity] +
+    magnitudeNorm * 4 +
+    recencyBoost +
+    meta.priority * 0.1
+  )
+}
+
+function applyDuplicatePenalty(observations: Observation[]): Observation[] {
+  const seenDetectors = new Set<string>()
+  return observations.map((o) => {
+    if (seenDetectors.has(o.detector)) {
+      return { ...o, rankScore: o.rankScore - 1.5 }
+    }
+    seenDetectors.add(o.detector)
+    return o
+  })
+}
+
+function assertDescriptive(o: Observation): void {
+  if (process.env.NODE_ENV === 'production') return
+  if (BANLIST_REGEX.test(o.title) || BANLIST_REGEX.test(o.oneLiner)) {
+    console.warn(
+      `[observations] Detector "${o.detector}" produced text containing a banned imperative verb. ` +
+        `Title: "${o.title}". One-liner: "${o.oneLiner}". Observations must be descriptive, not prescriptive.`
+    )
+  }
+}
+
+const ALLOCATION_DETECTORS = [
+  detectTopAccountConcentration,
+  detectCashLowYield,
+  detectFxExposure,
+  detectStaleBalances,
+  detectRecurringReviewBacklog,
+]
+
+const SPENDING_DETECTORS = [
+  detectYoyCategorySpike,
+  detectMonthlyOutlier,
+  detectForecastVsBudgetGap,
+  detectRecurringRunRate,
+]
+
+function rankPool(
+  detectors: Array<(input: ObservationsInput) => Observation[]>,
+  input: ObservationsInput,
+  limit: number
+): Observation[] {
+  const all: Observation[] = []
+  for (const d of detectors) {
+    try {
+      const obs = d(input)
+      for (const o of obs) {
+        assertDescriptive(o)
+        all.push(o)
+      }
+    } catch (err) {
+      console.error(`[observations] detector "${d.name}" threw`, err)
+    }
+  }
+  const scored = all.map((o) => ({ ...o, rankScore: score(o) }))
+  const penalized = applyDuplicatePenalty(
+    scored.slice().sort((a, b) => b.rankScore - a.rankScore || a.id.localeCompare(b.id))
+  )
+  return penalized
+    .slice()
+    .sort((a, b) => b.rankScore - a.rankScore || a.id.localeCompare(b.id))
+    .slice(0, limit)
+}
+
+export function rankAllocationObservations(
+  input: ObservationsInput,
+  limit = 5
+): Observation[] {
+  return rankPool(ALLOCATION_DETECTORS, input, limit)
+}
+
+export function rankSpendingObservations(
+  input: ObservationsInput,
+  limit = 5
+): Observation[] {
+  return rankPool(SPENDING_DETECTORS, input, limit)
+}


### PR DESCRIPTION
Surfaces deterministic, descriptive observations from the user's own data on the Key Insights page. Two tabs ("Allocation", "Spending") show the top 5 from each pool, ranked by severity + magnitude + recency with detector priority as soft tiebreak. Drill-in expands evidence rows and links to the relevant page (/accounts, /liquidity, /recurring, /analysis).

Detectors (allocation): top-1 / top-3 account concentration, cash & checking share of liquid, non-base-currency FX exposure, accounts not updated in >60 days, recurring charges flagged for review.

Detectors (spending): YoY category spike, monthly z-score outlier, forecast vs budget gap, recurring run-rate share of annual spend.

Wording is descriptive only — a dev-mode banlist warns if any detector emits imperative verbs (move/switch/should/recommend/etc.). A persistent disclaimer footer reinforces the framing.

Same lib also powers a new surface_observations chat tool so the AI assistant can answer "what should I focus on?" without duplicating ranking logic. Tool description instructs the model to paraphrase facts, not add advice.