### PR TITLE
feat(ui): UX overhaul — page header, skeletons, sync pill, confirm dialogs, filter bar, top movers, grouped nav, quick add

### DIFF
--- a/app/accounts/page.tsx
+++ b/app/accounts/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { AccountsOverview } from '@/components/accounts/accounts-overview'
 import { AddAccountDialog } from '@/components/accounts/add-account-dialog'
+import { PageHeader, PageHeaderBadge } from '@/components/ui/page-header'
 
 export default async function AccountsPage() {
   const supabase = await createClient()
@@ -15,28 +16,24 @@ export default async function AccountsPage() {
 
   return (
     <div className="space-y-4 md:space-y-6">
-      <div className="rounded-xl border border-l-[3px] border-l-blue-500 bg-gradient-to-r from-muted/50 to-muted/30 p-4 md:p-5">
-        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-          <div className="space-y-2">
-            <h1 className="text-2xl md:text-3xl font-bold">Accounts Overview</h1>
-            <p className="text-sm md:text-base text-muted-foreground">
-              Add and edit account balances directly in-app.
-            </p>
-            <div className="flex flex-wrap gap-2 text-xs">
-              <span className="rounded-full border bg-background px-2.5 py-1 font-medium">Input Mode: In-App</span>
-              <span className="rounded-full border bg-background px-2.5 py-1 font-medium">Optional refresh: Google Sheet transactions</span>
-            </div>
-          </div>
-          <div className="md:w-auto">
-            <AddAccountDialog
-              triggerLabel="Add Account"
-              triggerVariant="default"
-              triggerSize="default"
-              triggerClassName="w-full"
-            />
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        title="Accounts Overview"
+        description="Add and edit account balances directly in-app."
+        accent="blue"
+        badges={
+          <>
+            <PageHeaderBadge>Input Mode: In-App</PageHeaderBadge>
+            <PageHeaderBadge>Optional refresh: Google Sheet transactions</PageHeaderBadge>
+          </>
+        }
+        actions={
+          <AddAccountDialog
+            triggerLabel="Add Account"
+            triggerVariant="default"
+            triggerSize="default"
+          />
+        }
+      />
       <AccountsOverview />
     </div>
   )

--- a/app/analysis/page.tsx
+++ b/app/analysis/page.tsx
@@ -11,6 +11,7 @@ import { AnalysisHashScroll } from '@/components/analysis/analysis-hash-scroll'
 import { ForecastEvolutionSection } from '@/components/analysis/forecast-evolution-section'
 import { MonthlyCategoryTrendsSection } from '@/components/analysis/monthly-category-trends-section'
 import { AddTransactionDialog } from '@/components/transactions/add-transaction-dialog'
+import { PageHeader } from '@/components/ui/page-header'
 
 type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>
 
@@ -38,17 +39,12 @@ export default async function AnalysisPage({
   return (
     <div className="space-y-4 md:space-y-6">
       <AnalysisHashScroll />
-      <div className="rounded-xl border border-l-[3px] border-l-purple-500 bg-gradient-to-r from-muted/50 to-muted/30 p-4 md:p-5">
-        <div className="flex items-center justify-between gap-4">
-          <div className="space-y-1">
-            <h1 className="text-2xl md:text-3xl font-bold">Analysis & Trends</h1>
-            <p className="text-sm md:text-base text-muted-foreground">
-              Deep dive into spending patterns and year-over-year changes
-            </p>
-          </div>
-          <AddTransactionDialog />
-        </div>
-      </div>
+      <PageHeader
+        title="Analysis & Trends"
+        description="Deep dive into spending patterns and year-over-year changes"
+        accent="purple"
+        actions={<AddTransactionDialog />}
+      />
       <AnalysisNavigation />
       <div id="cash-runway" className="scroll-mt-24">
         <CashRunwayCards />

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -16,6 +16,7 @@ import {
   IncomeVsExpensesChartSkeleton,
 } from '@/components/dashboard/skeletons'
 import { IncomeVsExpensesChartWrapper } from '@/components/dashboard/income-vs-expenses-chart-wrapper'
+import { PageHeader } from '@/components/ui/page-header'
 
 export default async function DashboardPage() {
   const supabase = await createClient()
@@ -30,16 +31,17 @@ export default async function DashboardPage() {
   return (
     <div className="w-full max-w-7xl mx-auto space-y-2 md:space-y-3 flex flex-col">
       <DashboardHashScroll />
-      {/* Header - Renders immediately; on mobile Executive Summary is moved to top via order */}
+      {/* Header - on mobile, the Executive Summary is shown first via order so users see data before chrome */}
       <div className="max-md:order-2">
-        <h1 className="text-2xl md:text-3xl font-bold">Dashboard</h1>
-        <p className="text-sm md:text-base text-muted-foreground">
-          Overview of your financial position and trends
-        </p>
+        <PageHeader
+          title="Dashboard"
+          description="Overview of your financial position and trends"
+          accent="blue"
+        />
       </div>
 
       <div className="max-md:order-1">
-        <Suspense fallback={<div className="h-48 animate-pulse rounded-lg bg-muted" />}>
+        <Suspense fallback={<div className="skeleton-shimmer h-48 rounded-lg bg-muted" />}>
           <DashboardAtAGlanceWrapper />
         </Suspense>
       </div>

--- a/app/forecast/page.tsx
+++ b/app/forecast/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { ForecastPageWrapper } from '@/components/forecast/forecast-page-wrapper'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader } from '@/components/ui/page-header'
 
 export default async function ForecastPage() {
   const supabase = await createClient()
@@ -13,12 +14,11 @@ export default async function ForecastPage() {
 
   return (
     <div className="w-full max-w-7xl mx-auto space-y-3 md:space-y-4 flex flex-col">
-      <div>
-        <h1 className="text-2xl md:text-3xl font-bold">Forecast</h1>
-        <p className="text-sm md:text-base text-muted-foreground">
-          Three methodologies. Same data. The range across all three is your scenario band.
-        </p>
-      </div>
+      <PageHeader
+        title="Forecast"
+        description="Three methodologies. Same data. The range across all three is your scenario band."
+        accent="emerald"
+      />
 
       <Suspense fallback={<ForecastPageSkeleton />}>
         <ForecastPageWrapper />

--- a/app/globals.css
+++ b/app/globals.css
@@ -56,7 +56,7 @@
   body {
     @apply bg-background text-foreground antialiased;
     text-rendering: optimizeLegibility;
-    font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+    font-feature-settings: "cv02", "cv03", "cv04", "cv11", "tnum";
   }
 
   :where(
@@ -123,6 +123,32 @@
 /* Horizontal scroll containers: smooth touch scrolling on iOS */
 .scroll-touch {
   -webkit-overflow-scrolling: touch;
+}
+
+/* Skeleton shimmer: subtle moving highlight over the muted base */
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.skeleton-shimmer {
+  position: relative;
+  overflow: hidden;
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    hsl(var(--foreground) / 0.06) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  animation: skeleton-shimmer 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-shimmer {
+    animation: none;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { CsvImportFlow } from '@/components/import/csv-upload'
 import { SourceHealthPanel } from '@/components/ingestion/source-health-panel'
+import { PageHeader, PageHeaderBadge } from '@/components/ui/page-header'
 
 interface ImportPageProps {
   searchParams?: Promise<{ target?: string | string[] }>
@@ -27,17 +28,18 @@ export default async function ImportPage({ searchParams }: ImportPageProps) {
 
   return (
     <div className="space-y-4 md:space-y-6">
-      <div className="rounded-xl border bg-muted/30 p-4 md:p-5">
-        <h1 className="text-2xl md:text-3xl font-bold">Import CSV Data</h1>
-        <p className="mt-2 text-sm md:text-base text-muted-foreground">
-          Load native data into Findash without maintaining a live spreadsheet.
-        </p>
-        <div className="mt-3 flex flex-wrap gap-2 text-xs">
-          <span className="rounded-full border bg-background px-2.5 py-1 font-medium">Bulk source: CSV</span>
-          <span className="rounded-full border bg-background px-2.5 py-1 font-medium">Works for transactions, balances, recurring</span>
-          <span className="rounded-full border bg-background px-2.5 py-1 font-medium">Feeds the same forecast pipeline</span>
-        </div>
-      </div>
+      <PageHeader
+        title="Import CSV Data"
+        description="Load native data into Findash without maintaining a live spreadsheet."
+        accent="slate"
+        badges={
+          <>
+            <PageHeaderBadge>Bulk source: CSV</PageHeaderBadge>
+            <PageHeaderBadge>Works for transactions, balances, recurring</PageHeaderBadge>
+            <PageHeaderBadge>Feeds the same forecast pipeline</PageHeaderBadge>
+          </>
+        }
+      />
       <SourceHealthPanel
         title="Before you import"
         description="Check which datasets already exist so you can decide whether to append, review, or backfill with CSV."

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -8,6 +8,7 @@ import { InsightsDataBlock } from '@/components/insights/insights-data-block'
 import { InsightsDataHydrator } from '@/components/insights/insights-data-context'
 import { DUMMY_SHEET_ID } from '@/lib/ingestion-shared'
 import { fetchInsightsData } from '@/lib/insights-data'
+import { PageHeader } from '@/components/ui/page-header'
 
 export default async function InsightsPage() {
   const supabase = await createClient()
@@ -34,6 +35,11 @@ export default async function InsightsPage() {
       <InsightsDataHydrator data={initialData} />
       <InsightsHashScroll />
       <AutoSyncOnMount />
+      <PageHeader
+        title="Key Insights"
+        description="Quick overview of your financial performance and trends"
+        accent="purple"
+      />
       {needsSpreadsheet && (
         <div className="rounded-xl border border-dashed bg-muted/20 p-4 text-sm md:p-5">
           <div className="font-semibold">No live sheet connected</div>

--- a/app/kids/page.tsx
+++ b/app/kids/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { KidsAccountsOverview } from '@/components/kids/kids-accounts-overview'
 import { AddKidsAccountDialog } from '@/components/kids/add-kids-account-dialog'
+import { PageHeader, PageHeaderBadge } from '@/components/ui/page-header'
 
 export default async function KidsAccountsPage() {
   const supabase = await createClient()
@@ -15,27 +16,19 @@ export default async function KidsAccountsPage() {
 
   return (
     <div className="space-y-4 md:space-y-6">
-      <div className="rounded-xl border border-l-[3px] border-l-indigo-500 bg-gradient-to-r from-muted/50 to-muted/30 p-4 md:p-5">
-        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-          <div className="space-y-2">
-            <h1 className="text-2xl md:text-3xl font-bold">Kids Accounts</h1>
-            <p className="text-sm md:text-base text-muted-foreground">
-              Track each child&apos;s balances, purpose, and notes with in-app editing.
-            </p>
-            <div className="flex flex-wrap gap-2 text-xs">
-              <span className="rounded-full border bg-background px-2.5 py-1 font-medium">Input Mode: In-App</span>
-            </div>
-          </div>
-          <div className="w-full md:w-auto md:min-w-[220px]">
-            <AddKidsAccountDialog
-              triggerLabel="Add Kids Account"
-              triggerVariant="default"
-              triggerSize="default"
-              triggerClassName="w-full"
-            />
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        title="Kids Accounts"
+        description="Track each child's balances, purpose, and notes with in-app editing."
+        accent="indigo"
+        badges={<PageHeaderBadge>Input Mode: In-App</PageHeaderBadge>}
+        actions={
+          <AddKidsAccountDialog
+            triggerLabel="Add Kids Account"
+            triggerVariant="default"
+            triggerSize="default"
+          />
+        }
+      />
       <KidsAccountsOverview />
     </div>
   )

--- a/app/liquidity/page.tsx
+++ b/app/liquidity/page.tsx
@@ -9,6 +9,7 @@ import LiquidityDistribution from '@/components/liquidity/liquidity-distribution
 import RiskProfileTable from '@/components/liquidity/risk-profile-table'
 import HorizonProfileTable from '@/components/liquidity/horizon-profile-table'
 import { AddDebtDialog } from '@/components/liquidity/add-debt-dialog'
+import { PageHeader } from '@/components/ui/page-header'
 
 export default async function LiquidityPage() {
   const supabase = await createClient()
@@ -22,15 +23,12 @@ export default async function LiquidityPage() {
 
   return (
     <div className="space-y-4 md:space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold">Liquidity Overview</h1>
-          <p className="text-sm md:text-base text-muted-foreground">
-            Track cash position, debt obligations, and asset liquidity
-          </p>
-        </div>
-        <AddDebtDialog />
-      </div>
+      <PageHeader
+        title="Liquidity Overview"
+        description="Track cash position, debt obligations, and asset liquidity"
+        accent="orange"
+        actions={<AddDebtDialog />}
+      />
 
       <EnoughCalculator />
 

--- a/app/recurring/page.tsx
+++ b/app/recurring/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { RecurringPayments } from '@/components/recurring/recurring-payments'
 import { RecurringPaymentsTable } from '@/components/recurring/recurring-payments-table'
 import { AddRecurringPaymentDialog } from '@/components/recurring/add-recurring-payment-dialog'
+import { PageHeader, PageHeaderBadge } from '@/components/ui/page-header'
 
 export default async function RecurringPage() {
   const supabase = await createClient()
@@ -16,27 +17,19 @@ export default async function RecurringPage() {
 
   return (
     <div className="space-y-4 md:space-y-6">
-      <div className="rounded-xl border border-l-[3px] border-l-violet-500 bg-gradient-to-r from-muted/50 to-muted/30 p-4 md:p-5">
-        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-          <div className="space-y-2">
-            <h1 className="text-2xl md:text-3xl font-bold">Recurring Payments</h1>
-            <p className="text-sm md:text-base text-muted-foreground">
-              Manage subscriptions and commitments directly in-app.
-            </p>
-            <div className="flex flex-wrap gap-2 text-xs">
-              <span className="rounded-full border bg-background px-2.5 py-1 font-medium">Input Mode: In-App</span>
-            </div>
-          </div>
-          <div className="md:w-auto">
-            <AddRecurringPaymentDialog
-              triggerLabel="Add Recurring Payment"
-              triggerVariant="default"
-              triggerSize="default"
-              triggerClassName="w-full"
-            />
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        title="Recurring Payments"
+        description="Manage subscriptions and commitments directly in-app."
+        accent="violet"
+        badges={<PageHeaderBadge>Input Mode: In-App</PageHeaderBadge>}
+        actions={
+          <AddRecurringPaymentDialog
+            triggerLabel="Add Recurring Payment"
+            triggerVariant="default"
+            triggerSize="default"
+          />
+        }
+      />
       <RecurringPaymentsTable />
       <div className="pt-3 md:pt-4 border-t border-border">
         <RecurringPayments />

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { SettingsForm } from '@/components/settings/settings-form'
 import { AppearanceForm } from '@/components/settings/appearance-form'
 import { CategoryPlanningSection } from '@/components/settings/category-planning-section'
+import { PageHeader } from '@/components/ui/page-header'
 
 export default async function SettingsPage() {
   const supabase = await createClient()
@@ -24,23 +25,22 @@ export default async function SettingsPage() {
 
   return (
     <div className="space-y-4 md:space-y-6">
-      <div>
-        <h1 className="text-2xl md:text-3xl font-bold">Settings</h1>
-        <p className="text-sm md:text-base text-muted-foreground">
-          Preferences, data sources, category planning, and appearance.
-        </p>
-        <nav className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-sm" aria-label="Settings sections">
-          <a href="#google-sheet" className="text-muted-foreground hover:text-foreground underline-offset-4 hover:underline">
-            Data sources
-          </a>
-          <a href="#category-planning" className="text-muted-foreground hover:text-foreground underline-offset-4 hover:underline">
-            Category Planning
-          </a>
-          <a href="#appearance" className="text-muted-foreground hover:text-foreground underline-offset-4 hover:underline">
-            Appearance
-          </a>
-        </nav>
-      </div>
+      <PageHeader
+        title="Settings"
+        description="Preferences, data sources, category planning, and appearance."
+        accent="slate"
+      />
+      <nav className="flex flex-wrap gap-x-4 gap-y-1 -mt-2 text-sm" aria-label="Settings sections">
+        <a href="#google-sheet" className="text-muted-foreground hover:text-foreground underline-offset-4 hover:underline">
+          Data sources
+        </a>
+        <a href="#category-planning" className="text-muted-foreground hover:text-foreground underline-offset-4 hover:underline">
+          Category Planning
+        </a>
+        <a href="#appearance" className="text-muted-foreground hover:text-foreground underline-offset-4 hover:underline">
+          Appearance
+        </a>
+      </nav>
       <SettingsForm
         initialSpreadsheetId={profile?.google_spreadsheet_id ?? ''}
         initialDisplayName={profile?.display_name ?? ''}

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -5,6 +5,7 @@ import { isExpenseCategory } from '@/lib/category-filters'
 import { computeTodayHeadroom, type YearMethod } from '@/lib/today-headroom'
 import type { TodayPageData, TodayTransactionRow } from '@/lib/today-types'
 import { TodayPageContent } from '@/components/today/today-page-content'
+import { PageHeader } from '@/components/ui/page-header'
 
 function toLocalDateString(value: Date): string {
   const year = value.getFullYear()
@@ -214,14 +215,11 @@ export default async function TodayPage() {
 
   return (
     <div className="space-y-4 md:space-y-6">
-      <div className="hidden md:block rounded-xl border border-l-[3px] border-l-slate-500 bg-gradient-to-r from-muted/50 to-muted/30 p-4 md:p-5">
-        <div className="space-y-1">
-          <h1 className="text-2xl md:text-3xl font-bold">Today</h1>
-          <p className="text-sm md:text-base text-muted-foreground">
-            Today&apos;s spending snapshot: transactions, spend by category, and by forecast methodology
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        title="Today"
+        description="Today's spending snapshot: transactions, spend by category, and by forecast methodology"
+        accent="slate"
+      />
       <TodayPageContent data={data} />
     </div>
   )

--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { TransactionsList } from '@/components/transactions/transactions-list'
+import { PageHeader } from '@/components/ui/page-header'
 
 export default async function TransactionsPage() {
   const supabase = await createClient()
@@ -14,6 +15,11 @@ export default async function TransactionsPage() {
 
   return (
     <div className="space-y-4 md:space-y-6">
+      <PageHeader
+        title="Transactions"
+        description="Search, filter, and review your synced and imported transactions."
+        accent="blue"
+      />
       <TransactionsList />
     </div>
   )

--- a/components/accounts/edit-account-dialog.tsx
+++ b/components/accounts/edit-account-dialog.tsx
@@ -20,6 +20,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { AccountBalance } from '@/lib/types'
 import { queryKeys } from '@/lib/query-keys'
 
@@ -68,6 +69,7 @@ export function EditAccountDialog({ account, open, onOpenChange }: EditAccountDi
   const queryClient = useQueryClient()
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
 
   const [institution, setInstitution] = useState(account.institution)
   const [accountName, setAccountName] = useState(account.account_name)
@@ -285,7 +287,7 @@ export function EditAccountDialog({ account, open, onOpenChange }: EditAccountDi
             <Button
               type="button"
               variant="destructive"
-              onClick={handleDelete}
+              onClick={() => setConfirmDeleteOpen(true)}
               disabled={saving || deleting}
             >
               {deleting ? 'Deleting...' : 'Delete'}
@@ -293,6 +295,21 @@ export function EditAccountDialog({ account, open, onOpenChange }: EditAccountDi
           </div>
         </form>
       </DialogContent>
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        onOpenChange={setConfirmDeleteOpen}
+        title="Delete account?"
+        description={
+          <>
+            This will permanently remove <strong>{account.account_name}</strong> at{' '}
+            <strong>{account.institution}</strong> and its current balance from your records. This
+            action cannot be undone.
+          </>
+        }
+        confirmLabel="Delete"
+        destructive
+        onConfirm={handleDelete}
+      />
     </Dialog>
   )
 }

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -15,6 +15,11 @@ const ChatWidget = dynamic(
   { ssr: false }
 )
 
+const QuickAdd = dynamic(
+  () => import('@/components/quick-add').then(m => ({ default: m.QuickAdd })),
+  { ssr: false }
+)
+
 interface AppShellProps {
   children: React.ReactNode
   initialHeaderData?: HeaderStatus | null
@@ -72,6 +77,7 @@ export function AppShell({ children, initialHeaderData }: AppShellProps) {
       </div>
       <Toaster position="top-right" richColors />
       <ChatWidget />
+      <QuickAdd />
     </>
   )
 }

--- a/components/dashboard/dashboard-at-a-glance.tsx
+++ b/components/dashboard/dashboard-at-a-glance.tsx
@@ -5,6 +5,7 @@ import { useCurrency } from '@/lib/contexts/currency-context'
 import { LineChart, Receipt, Calendar, CalendarDays, ChevronRight } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/utils/cn'
 import { useIsMobile } from '@/lib/hooks/use-is-mobile'
 import { getBudgetStatusConfig } from '@/lib/budget-status'
@@ -86,12 +87,12 @@ export function DashboardAtAGlance({ data }: { data: DashboardAtAGlanceData | nu
 
   const getCardContent = (sectionId: string) => {
     if (sectionId === 'net-worth-chart') {
-      if (loading) return <span className="text-sm text-muted-foreground">Loading...</span>
+      if (loading) return <Skeleton className="h-8 w-28" aria-label="Loading" />
       if (netWorth != null) return <span className="text-2xl font-bold tabular-nums">{symbol}{formatCompact(netWorth)}</span>
       return <span className="text-sm text-muted-foreground">&mdash;</span>
     }
     if (sectionId === 'budget-table') {
-      if (loading) return <span className="text-sm text-muted-foreground">Loading...</span>
+      if (loading) return <Skeleton className="h-8 w-28" aria-label="Loading" />
       if (budgetStatusInfo) {
         return (
           <span className={cn('text-2xl font-bold tabular-nums', budgetStatusInfo.textClass)}>
@@ -103,7 +104,7 @@ export function DashboardAtAGlance({ data }: { data: DashboardAtAGlanceData | nu
       return <span className="text-sm text-muted-foreground">&mdash;</span>
     }
     if (sectionId === 'income-vs-expenses') {
-      if (loading) return <span className="text-sm text-muted-foreground">Loading...</span>
+      if (loading) return <Skeleton className="h-8 w-28" aria-label="Loading" />
       if (incomeTotal != null && expensesTotal != null) {
         return (
           <span className="text-2xl font-bold tabular-nums">
@@ -114,7 +115,7 @@ export function DashboardAtAGlance({ data }: { data: DashboardAtAGlanceData | nu
       return <span className="text-sm text-muted-foreground">&mdash;</span>
     }
     if (sectionId === 'annual-trends') {
-      if (loading) return <span className="text-sm text-muted-foreground">Loading...</span>
+      if (loading) return <Skeleton className="h-8 w-28" aria-label="Loading" />
       if (data?.expensesForecastGbp != null) {
         const val = toDisplayCurrency(data.expensesForecastGbp)
         return <span className="text-2xl font-bold tabular-nums">{symbol}{formatCompact(Math.abs(val))}</span>
@@ -122,7 +123,7 @@ export function DashboardAtAGlance({ data }: { data: DashboardAtAGlanceData | nu
       return <span className="text-sm text-muted-foreground">&mdash;</span>
     }
     if (sectionId === 'monthly-trends') {
-      if (loading) return <span className="text-sm text-muted-foreground">Loading...</span>
+      if (loading) return <Skeleton className="h-8 w-28" aria-label="Loading" />
       if (data?.monthlyEstGbp != null) {
         const val = toDisplayCurrency(data.monthlyEstGbp)
         return <span className="text-2xl font-bold tabular-nums">{symbol}{formatCompact(Math.abs(val))}</span>

--- a/components/forecast/forecast-page-client.tsx
+++ b/components/forecast/forecast-page-client.tsx
@@ -11,6 +11,7 @@ import { ForecastCategoryTable } from './forecast-category-table'
 import { ForecastCategoryDrilldown } from './forecast-category-drilldown'
 import { ForecastBacktestPanel } from './forecast-backtest-panel'
 import { ForecastMethodologyNotes } from './forecast-methodology-notes'
+import { ForecastTopMovers } from './forecast-top-movers'
 
 export function ForecastPageClient({
   initialData,
@@ -47,6 +48,13 @@ export function ForecastPageClient({
     <div className="space-y-4 md:space-y-6">
       <section id="forecast-summary" className="scroll-mt-24">
         <ForecastSummaryCards data={data} />
+      </section>
+
+      <section
+        id="forecast-top-movers"
+        className="scroll-mt-24 pt-3 md:pt-4 border-t border-border"
+      >
+        <ForecastTopMovers data={data} />
       </section>
 
       <section

--- a/components/forecast/forecast-top-movers.tsx
+++ b/components/forecast/forecast-top-movers.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useMemo } from 'react'
+import { TrendingUp, TrendingDown } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useCurrency } from '@/lib/contexts/currency-context'
+import { cn } from '@/utils/cn'
+import type { TransactionForecastResult } from '@/lib/forecast-transaction-based'
+
+interface ForecastTopMoversProps {
+  data: TransactionForecastResult
+}
+
+interface Mover {
+  category: string
+  delta: number
+  pct: number | null
+  forecast: number
+  prior: number
+}
+
+function formatMoney(value: number, symbol: string) {
+  const sign = value < 0 ? '-' : ''
+  return `${sign}${symbol}${Math.abs(value).toLocaleString(undefined, {
+    maximumFractionDigits: 0,
+  })}`
+}
+
+function formatPct(pct: number | null) {
+  if (pct == null || !Number.isFinite(pct)) return '—'
+  const sign = pct > 0 ? '+' : pct < 0 ? '−' : ''
+  return `${sign}${Math.abs(pct).toFixed(0)}%`
+}
+
+export function ForecastTopMovers({ data }: ForecastTopMoversProps) {
+  const { currency, fxRate } = useCurrency()
+  const symbol = currency === 'USD' ? '$' : '£'
+
+  const movers = useMemo<{ ups: Mover[]; downs: Mover[] }>(() => {
+    const all: Mover[] = []
+    for (const c of data.ensemble.categories) {
+      const forecast = c.fullYearBase
+      const prior = c.priorYearActual
+      if (forecast <= 0 && prior <= 0) continue
+      const delta = forecast - prior
+      const pct = prior > 0 ? (delta / prior) * 100 : null
+      all.push({ category: c.category, delta, pct, forecast, prior })
+    }
+    const convert = (v: number) => (currency === 'USD' ? v * (fxRate || 1) : v)
+    const mapped = all.map((m) => ({
+      ...m,
+      delta: convert(m.delta),
+      forecast: convert(m.forecast),
+      prior: convert(m.prior),
+    }))
+    const ups = [...mapped].sort((a, b) => b.delta - a.delta).slice(0, 5).filter((m) => m.delta > 0)
+    const downs = [...mapped].sort((a, b) => a.delta - b.delta).slice(0, 5).filter((m) => m.delta < 0)
+    return { ups, downs }
+  }, [data, currency, fxRate])
+
+  if (movers.ups.length === 0 && movers.downs.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Top movers vs prior year</CardTitle>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Categories where this year's forecast diverges most from last year's actuals.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <MoverList
+            heading="Trending higher"
+            icon={TrendingUp}
+            tone="up"
+            movers={movers.ups}
+            symbol={symbol}
+          />
+          <MoverList
+            heading="Trending lower"
+            icon={TrendingDown}
+            tone="down"
+            movers={movers.downs}
+            symbol={symbol}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+interface MoverListProps {
+  heading: string
+  icon: typeof TrendingUp
+  tone: 'up' | 'down'
+  movers: Mover[]
+  symbol: string
+}
+
+function MoverList({ heading, icon: Icon, tone, movers, symbol }: MoverListProps) {
+  return (
+    <div className="space-y-2">
+      <div
+        className={cn(
+          'flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide',
+          tone === 'up'
+            ? 'text-red-600 dark:text-red-400'
+            : 'text-emerald-600 dark:text-emerald-400',
+        )}
+      >
+        <Icon className="h-3.5 w-3.5" aria-hidden />
+        {heading}
+      </div>
+      {movers.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Nothing notable.</p>
+      ) : (
+        <ul className="divide-y rounded-md border">
+          {movers.map((m) => (
+            <li key={m.category} className="flex items-center justify-between gap-3 px-3 py-2">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">{m.category}</p>
+                <p className="text-xs text-muted-foreground">
+                  {formatMoney(m.prior, symbol)} → {formatMoney(m.forecast, symbol)}
+                </p>
+              </div>
+              <div className="shrink-0 text-right">
+                <p
+                  className={cn(
+                    'text-sm font-semibold',
+                    tone === 'up'
+                      ? 'text-red-600 dark:text-red-400'
+                      : 'text-emerald-600 dark:text-emerald-400',
+                  )}
+                >
+                  {tone === 'up' ? '+' : ''}
+                  {formatMoney(m.delta, symbol)}
+                </p>
+                <p className="text-xs text-muted-foreground">{formatPct(m.pct)}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,8 +2,9 @@
 
 import { CurrencyToggle } from './currency-toggle'
 import { ThemeToggle } from './theme-toggle'
+import { SyncStatusPill } from './sync-status-pill'
 import { Button } from './ui/button'
-import { RefreshCw, MessageCircle } from 'lucide-react'
+import { RefreshCw, MessageCircle, Plus } from 'lucide-react'
 import { useState, useEffect, useRef } from 'react'
 import { useIsMobile } from '@/lib/hooks/use-is-mobile'
 import { useSync } from '@/lib/contexts/sync-context'
@@ -23,11 +24,9 @@ export function Header({ initialData: _initialData }: { initialData?: HeaderStat
   const {
     syncing,
     handleSync,
-    lastRefreshDate,
     latestTransactionDate,
     maxAccountDate,
     ingestionStatus,
-    formatLastSheetSync,
     formatDate,
   } = useSync()
   const [mounted, setMounted] = useState(false)
@@ -102,25 +101,18 @@ export function Header({ initialData: _initialData }: { initialData?: HeaderStat
         
         {mounted && (
           <>
-            <div className="min-w-0 text-xs text-muted-foreground md:hidden">
-              <span className="text-foreground">
-                {syncing ? 'Refreshing...' : ingestionStatus?.freshness === 'setup' ? 'Add a source' : formatLastSheetSync(lastRefreshDate)}
-              </span>
-            </div>
-            <div className="hidden min-w-0 items-center gap-2 text-xs text-muted-foreground md:flex md:gap-3 lg:gap-4">
-              <div className="hidden md:block">
-                <span className="font-medium">Source Health:</span>{' '}
-                <span className="text-foreground">{ingestionStatus?.freshnessLabel ?? formatLastSheetSync(lastRefreshDate)}</span>
-              </div>
-              <div className="hidden md:block">
+            <SyncStatusPill className="md:hidden" />
+            <div className="hidden min-w-0 items-center gap-2 md:flex md:gap-3 lg:gap-4">
+              <SyncStatusPill />
+              <div className="hidden text-xs text-muted-foreground md:block">
                 <span className="font-medium">Sources:</span>{' '}
                 <span className="text-foreground">{ingestionStatus?.connectedSources ?? 0}</span>
               </div>
-              <div className="hidden lg:block">
+              <div className="hidden text-xs text-muted-foreground lg:block">
                 <span className="font-medium">Latest Transaction:</span>{' '}
                 <span className="text-foreground">{formatDate(latestTransactionDate)}</span>
               </div>
-              <div className="hidden lg:block">
+              <div className="hidden text-xs text-muted-foreground lg:block">
                 <span className="font-medium">Latest Account:</span>{' '}
                 <span className="text-foreground">{formatDate(maxAccountDate)}</span>
               </div>
@@ -129,6 +121,18 @@ export function Header({ initialData: _initialData }: { initialData?: HeaderStat
         )}
       </div>
       <div className="flex items-center gap-1.5 md:gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => window.dispatchEvent(new Event('findash:open-quick-add'))}
+          className="hidden h-9 gap-1.5 px-2 text-xs md:inline-flex md:px-3 md:text-sm"
+          title="Quick add (⌘K)"
+          aria-label="Quick add"
+        >
+          <Plus className="h-4 w-4" />
+          <span className="hidden lg:inline">Quick add</span>
+        </Button>
         <Button
           type="button"
           variant="ghost"

--- a/components/insights/insights-data-block.tsx
+++ b/components/insights/insights-data-block.tsx
@@ -3,17 +3,11 @@ import { KeyInsights } from './key-insights'
 import { ObservationsSection } from './observations-section'
 
 /**
- * Presentational block for Key Insights heading + preloaded payload.
+ * Presentational block for Key Insights preloaded payload.
  */
 export function InsightsDataBlock({ initialData }: { initialData: InsightsDataPayload }) {
   return (
     <>
-      <div className="hidden md:block">
-        <h1 className="text-2xl md:text-3xl font-bold">Key Insights</h1>
-        <p className="text-sm md:text-base text-muted-foreground">
-          Quick overview of your financial performance and trends
-        </p>
-      </div>
       <KeyInsights initialData={initialData} />
       <ObservationsSection
         allocation={initialData.allocationObservations ?? []}

--- a/components/kids/edit-kids-account-dialog.tsx
+++ b/components/kids/edit-kids-account-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { KidsAccount } from '@/lib/types'
 import { queryKeys } from '@/lib/query-keys'
 
@@ -34,6 +35,7 @@ export function EditKidsAccountDialog({ account, open, onOpenChange }: EditKidsA
   const queryClient = useQueryClient()
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
 
   const [childName, setChildName] = useState(account.child_name)
   const [accountType, setAccountType] = useState(account.account_type)
@@ -193,7 +195,7 @@ export function EditKidsAccountDialog({ account, open, onOpenChange }: EditKidsA
             <Button
               type="button"
               variant="destructive"
-              onClick={handleDelete}
+              onClick={() => setConfirmDeleteOpen(true)}
               disabled={saving || deleting}
             >
               {deleting ? 'Deleting...' : 'Delete'}
@@ -201,6 +203,20 @@ export function EditKidsAccountDialog({ account, open, onOpenChange }: EditKidsA
           </div>
         </form>
       </DialogContent>
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        onOpenChange={setConfirmDeleteOpen}
+        title="Delete kids account?"
+        description={
+          <>
+            This will permanently remove <strong>{account.child_name}</strong>'s{' '}
+            <strong>{account.account_type}</strong> account. This action cannot be undone.
+          </>
+        }
+        confirmLabel="Delete"
+        destructive
+        onConfirm={handleDelete}
+      />
     </Dialog>
   )
 }

--- a/components/liquidity/committed-capital-vs-cash.tsx
+++ b/components/liquidity/committed-capital-vs-cash.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react'
 import { AccountBalance, Debt } from '@/lib/types'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useCurrency } from '@/lib/contexts/currency-context'
 import { useIsMobile } from '@/lib/hooks/use-is-mobile'
 import { useChartTheme } from '@/lib/hooks/use-chart-theme'
@@ -103,12 +104,7 @@ export default function CommittedCapitalVsCash() {
           <CardTitle>Committed Capital vs. Liquidity</CardTitle>
         </CardHeader>
         <CardContent>
-          <div
-            className="flex items-center justify-center"
-            style={{ height: chartHeight }}
-          >
-            <p className="text-sm text-muted-foreground">Loading...</p>
-          </div>
+          <Skeleton className="w-full" style={{ height: chartHeight }} aria-label="Loading chart" />
         </CardContent>
       </Card>
     )

--- a/components/liquidity/debt-overview.tsx
+++ b/components/liquidity/debt-overview.tsx
@@ -5,6 +5,7 @@ import { useAccounts } from '@/lib/hooks/queries/use-accounts'
 import { useDebt } from '@/lib/hooks/queries/use-debt'
 import { AccountBalance, Debt } from '@/lib/types'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -138,12 +139,7 @@ export default function DebtOverview() {
           <CardTitle>Debt vs Assets</CardTitle>
         </CardHeader>
         <CardContent>
-          <div
-            className="flex items-center justify-center"
-            style={{ height: chartHeight }}
-          >
-            <p className="text-sm text-muted-foreground">Loading...</p>
-          </div>
+          <Skeleton className="w-full" style={{ height: chartHeight }} aria-label="Loading chart" />
         </CardContent>
       </Card>
     )

--- a/components/liquidity/edit-debt-dialog.tsx
+++ b/components/liquidity/edit-debt-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Debt } from '@/lib/types'
 import { useCurrency } from '@/lib/contexts/currency-context'
 import { queryKeys } from '@/lib/query-keys'
@@ -31,6 +32,7 @@ export function EditDebtDialog({ debt, open, onOpenChange }: EditDebtDialogProps
   const { currency, fxRate } = useCurrency()
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
 
   const initialAmount = currency === 'USD'
     ? (debt.amount_usd ?? (debt.amount_gbp ?? 0) * (fxRate || 1))
@@ -171,7 +173,7 @@ export function EditDebtDialog({ debt, open, onOpenChange }: EditDebtDialogProps
             <Button
               type="button"
               variant="destructive"
-              onClick={handleDelete}
+              onClick={() => setConfirmDeleteOpen(true)}
               disabled={saving || deleting}
             >
               {deleting ? 'Deleting...' : 'Delete'}
@@ -179,6 +181,21 @@ export function EditDebtDialog({ debt, open, onOpenChange }: EditDebtDialogProps
           </div>
         </form>
       </DialogContent>
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        onOpenChange={setConfirmDeleteOpen}
+        title="Delete debt entry?"
+        description={
+          <>
+            This will permanently remove <strong>{debt.name}</strong>
+            {debt.purpose ? <> ({debt.purpose})</> : null} from your liabilities. This
+            action cannot be undone.
+          </>
+        }
+        confirmLabel="Delete"
+        destructive
+        onConfirm={handleDelete}
+      />
     </Dialog>
   )
 }

--- a/components/liquidity/horizon-profile-table.tsx
+++ b/components/liquidity/horizon-profile-table.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { AccountBalance } from '@/lib/types'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -123,9 +124,7 @@ export default function HorizonProfileTable() {
           <CardTitle>Horizon Profile Breakdown</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex items-center justify-center" style={{ height: 200 }}>
-            <p className="text-sm text-muted-foreground">Loading...</p>
-          </div>
+          <Skeleton className="w-full" style={{ height: 200 }} aria-label="Loading table" />
         </CardContent>
       </Card>
     )

--- a/components/liquidity/liquidity-distribution.tsx
+++ b/components/liquidity/liquidity-distribution.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { AccountBalance } from '@/lib/types'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useCurrency } from '@/lib/contexts/currency-context'
 import { useIsMobile } from '@/lib/hooks/use-is-mobile'
 import { useChartTheme } from '@/lib/hooks/use-chart-theme'
@@ -111,12 +112,7 @@ export default function LiquidityDistribution() {
           <CardTitle>Liquidity Distribution</CardTitle>
         </CardHeader>
         <CardContent>
-          <div
-            className="flex items-center justify-center"
-            style={{ height: chartHeight }}
-          >
-            <p className="text-sm text-muted-foreground">Loading...</p>
-          </div>
+          <Skeleton className="w-full" style={{ height: chartHeight }} aria-label="Loading chart" />
         </CardContent>
       </Card>
     )

--- a/components/liquidity/monthly-expenses-vs-liquidity.tsx
+++ b/components/liquidity/monthly-expenses-vs-liquidity.tsx
@@ -5,6 +5,7 @@ import { useAccounts } from '@/lib/hooks/queries/use-accounts'
 import { useCashRunway } from '@/lib/hooks/queries/use-cash-runway'
 import { AccountBalance } from '@/lib/types'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useCurrency } from '@/lib/contexts/currency-context'
 import { useIsMobile } from '@/lib/hooks/use-is-mobile'
 import { useChartTheme } from '@/lib/hooks/use-chart-theme'
@@ -101,12 +102,7 @@ export default function MonthlyExpensesVsLiquidity() {
           <CardTitle>Monthly Expenses vs. Liquidity</CardTitle>
         </CardHeader>
         <CardContent>
-          <div
-            className="flex items-center justify-center"
-            style={{ height: chartHeight }}
-          >
-            <p className="text-sm text-muted-foreground">Loading...</p>
-          </div>
+          <Skeleton className="w-full" style={{ height: chartHeight }} aria-label="Loading chart" />
         </CardContent>
       </Card>
     )

--- a/components/liquidity/risk-profile-table.tsx
+++ b/components/liquidity/risk-profile-table.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { AccountBalance } from '@/lib/types'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -123,9 +124,7 @@ export default function RiskProfileTable() {
           <CardTitle>Risk Profile Breakdown</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex items-center justify-center" style={{ height: 200 }}>
-            <p className="text-sm text-muted-foreground">Loading...</p>
-          </div>
+          <Skeleton className="w-full" style={{ height: 200 }} aria-label="Loading table" />
         </CardContent>
       </Card>
     )

--- a/components/quick-add.tsx
+++ b/components/quick-add.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Plus, Receipt, Wallet, Repeat, CreditCard, Baby, FileUp } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { AddTransactionDialog } from './transactions/add-transaction-dialog'
+
+const QUICK_ADD_EVENT = 'findash:open-quick-add'
+
+const SHORTCUTS: { href: string; label: string; description: string; icon: typeof Receipt }[] = [
+  { href: '/accounts', label: 'Account', description: 'Add a checking, brokerage or other account', icon: Wallet },
+  { href: '/recurring', label: 'Recurring payment', description: 'Track a subscription or fixed expense', icon: Repeat },
+  { href: '/liquidity', label: 'Debt', description: 'Mortgage, loan, credit card or commitment', icon: CreditCard },
+  { href: '/kids', label: 'Kids account', description: '529, UGMA or other custodial account', icon: Baby },
+  { href: '/import', label: 'Import CSV', description: 'Bulk import transactions or balances', icon: FileUp },
+]
+
+export function QuickAdd() {
+  const [launcherOpen, setLauncherOpen] = useState(false)
+  const [transactionOpen, setTransactionOpen] = useState(false)
+
+  useEffect(() => {
+    const handler = () => setLauncherOpen(true)
+    window.addEventListener(QUICK_ADD_EVENT, handler)
+    return () => window.removeEventListener(QUICK_ADD_EVENT, handler)
+  }, [])
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!((e.metaKey || e.ctrlKey) && e.key === 'k')) return
+      const target = e.target as HTMLElement | null
+      const tag = target?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return
+      e.preventDefault()
+      setLauncherOpen((v) => !v)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  const openTransaction = () => {
+    setLauncherOpen(false)
+    window.setTimeout(() => setTransactionOpen(true), 60)
+  }
+
+  return (
+    <>
+      <Dialog open={launcherOpen} onOpenChange={setLauncherOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Plus className="h-5 w-5" /> Quick add
+            </DialogTitle>
+            <DialogDescription>
+              <span className="hidden md:inline">Press </span>
+              <kbd className="hidden rounded border bg-muted px-1 py-0.5 text-[10px] font-medium md:inline">⌘K</kbd>
+              <span className="hidden md:inline"> from anywhere to open this menu.</span>
+              <span className="md:hidden">Pick what to add.</span>
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid grid-cols-1 gap-1.5">
+            <button
+              type="button"
+              onClick={openTransaction}
+              className="flex items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <Receipt className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0">
+                <p className="text-sm font-medium">Transaction</p>
+                <p className="text-xs text-muted-foreground">Log a manual purchase or income</p>
+              </div>
+            </button>
+            {SHORTCUTS.map((s) => {
+              const Icon = s.icon
+              return (
+                <Link
+                  key={s.href}
+                  href={s.href}
+                  onClick={() => setLauncherOpen(false)}
+                  className="flex items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium">{s.label}</p>
+                    <p className="text-xs text-muted-foreground">{s.description}</p>
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <AddTransactionDialog
+        open={transactionOpen}
+        onOpenChange={setTransactionOpen}
+        hideTrigger
+      />
+    </>
+  )
+}

--- a/components/recurring/edit-recurring-payment-dialog.tsx
+++ b/components/recurring/edit-recurring-payment-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { RecurringPayment } from '@/lib/types'
 import { useCurrency } from '@/lib/contexts/currency-context'
 import { queryKeys } from '@/lib/query-keys'
@@ -29,6 +30,7 @@ export function EditRecurringPaymentDialog({ payment, open, onOpenChange }: Edit
   const { currency, fxRate } = useCurrency()
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
 
   // Show amount in active currency
   const initialAmount = currency === 'USD'
@@ -205,7 +207,7 @@ export function EditRecurringPaymentDialog({ payment, open, onOpenChange }: Edit
             <Button
               type="button"
               variant="destructive"
-              onClick={handleDelete}
+              onClick={() => setConfirmDeleteOpen(true)}
               disabled={saving || deleting}
             >
               {deleting ? 'Deleting...' : 'Delete'}
@@ -213,6 +215,20 @@ export function EditRecurringPaymentDialog({ payment, open, onOpenChange }: Edit
           </div>
         </form>
       </DialogContent>
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        onOpenChange={setConfirmDeleteOpen}
+        title="Delete recurring payment?"
+        description={
+          <>
+            This will permanently remove <strong>{payment.name}</strong> from your recurring
+            payments. This action cannot be undone.
+          </>
+        }
+        confirmLabel="Delete"
+        destructive
+        onConfirm={handleDelete}
+      />
     </Dialog>
   )
 }

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { cn } from '@/utils/cn'
-import { LayoutDashboard, Wallet, Receipt, TrendingUp, Lightbulb, ChevronLeft, ChevronRight, Repeat, Baby, MoreHorizontal, Settings, Droplets, FileUp, MessageCircle, LogOut, Calendar, LayoutList, LineChart } from 'lucide-react'
+import { LayoutDashboard, Wallet, Receipt, TrendingUp, Lightbulb, ChevronLeft, ChevronRight, Repeat, Baby, MoreHorizontal, Settings, Droplets, FileUp, MessageCircle, LogOut, Calendar, LayoutList, LineChart, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -14,20 +14,53 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { createClient } from '@/lib/supabase/client'
-const allNavigation = [
-  { name: 'Daily Summary', mobileLabel: 'Summary', href: '/', icon: LayoutList },
-  { name: 'Key Insights', mobileLabel: 'Insights', href: '/insights', icon: Lightbulb },
-  { name: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
-  { name: 'Today', href: '/today', icon: Calendar },
-  { name: 'Accounts', href: '/accounts', icon: Wallet },
-  { name: 'Transactions', href: '/transactions', icon: Receipt },
-  { name: 'Liquidity', href: '/liquidity', icon: Droplets },
-  { name: 'Kids Accounts', href: '/kids', icon: Baby },
-  { name: 'Analysis', href: '/analysis', icon: TrendingUp },
-  { name: 'Forecast', href: '/forecast', icon: LineChart },
-  { name: 'Recurring', href: '/recurring', icon: Repeat },
-  { name: 'Import', href: '/import', icon: FileUp },
-  { name: 'Settings', href: '/settings', icon: Settings },
+
+type NavItem = {
+  name: string
+  mobileLabel?: string
+  href: string
+  icon: typeof LayoutDashboard
+}
+
+type NavGroup = {
+  label: string
+  items: NavItem[]
+}
+
+const NAV_GROUPS: NavGroup[] = [
+  {
+    label: 'Overview',
+    items: [
+      { name: 'Daily Summary', mobileLabel: 'Summary', href: '/', icon: LayoutList },
+      { name: 'Key Insights', mobileLabel: 'Insights', href: '/insights', icon: Lightbulb },
+      { name: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
+      { name: 'Today', href: '/today', icon: Calendar },
+    ],
+  },
+  {
+    label: 'Money',
+    items: [
+      { name: 'Accounts', href: '/accounts', icon: Wallet },
+      { name: 'Transactions', href: '/transactions', icon: Receipt },
+      { name: 'Liquidity', href: '/liquidity', icon: Droplets },
+      { name: 'Kids Accounts', href: '/kids', icon: Baby },
+    ],
+  },
+  {
+    label: 'Planning',
+    items: [
+      { name: 'Analysis', href: '/analysis', icon: TrendingUp },
+      { name: 'Forecast', href: '/forecast', icon: LineChart },
+      { name: 'Recurring', href: '/recurring', icon: Repeat },
+    ],
+  },
+  {
+    label: 'Setup',
+    items: [
+      { name: 'Import', href: '/import', icon: FileUp },
+      { name: 'Settings', href: '/settings', icon: Settings },
+    ],
+  },
 ]
 
 function isRouteActive(pathname: string, href: string) {
@@ -59,25 +92,37 @@ export function Sidebar() {
       })
   }, [])
 
-  const navigation = useMemo(() => {
-    return hasKidsData ? allNavigation : allNavigation.filter((item) => item.href !== '/kids')
+  const groups = useMemo(() => {
+    if (hasKidsData) return NAV_GROUPS
+    return NAV_GROUPS.map((g) => ({
+      ...g,
+      items: g.items.filter((i) => i.href !== '/kids'),
+    }))
   }, [hasKidsData])
 
-  const mobilePrimaryNav = useMemo(() => navigation.slice(0, 3), [navigation])
-  const mobileMoreNav = useMemo(() => navigation.slice(3), [navigation])
+  // Mobile bottom nav: 4 most-used + AI + More.
+  const mobilePrimary = useMemo<NavItem[]>(() => {
+    const overview = groups.find((g) => g.label === 'Overview')?.items ?? []
+    const transactions = groups.find((g) => g.label === 'Money')?.items.find((i) => i.href === '/transactions')
+    const dashboard = overview.find((i) => i.href === '/dashboard')
+    const summary = overview.find((i) => i.href === '/')
+    const items: NavItem[] = [summary, dashboard, transactions].filter((i): i is NavItem => Boolean(i))
+    return items
+  }, [groups])
 
-  // Sidebar always defaults to open (not collapsed)
-  // Removed localStorage loading so it always starts open when entering the app
-  const toggleCollapse = () => {
-    setCollapsed(!collapsed)
-    // Note: We don't persist the collapsed state to localStorage
-    // so the sidebar always opens when entering the app
-  }
+  const toggleCollapse = () => setCollapsed(!collapsed)
 
   const openMobileAssistant = () => {
     setMoreOpen(false)
     window.setTimeout(() => {
       window.dispatchEvent(new Event('findash:open-chat-widget'))
+    }, 120)
+  }
+
+  const openQuickAdd = () => {
+    setMoreOpen(false)
+    window.setTimeout(() => {
+      window.dispatchEvent(new Event('findash:open-quick-add'))
     }, 120)
   }
 
@@ -113,32 +158,41 @@ export function Sidebar() {
             )}
           </Button>
         </div>
-        <nav className="flex-1 space-y-1 px-3 py-4">
-          {navigation.map((item) => {
-            const isActive = isRouteActive(pathname, item.href)
-            return (
-              <Link
-                key={item.name}
-                href={item.href}
-                prefetch={true}
-                className={cn(
-                  'group flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-[color,background-color,transform] duration-150',
-                  'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-                  isActive
-                    ? 'bg-primary text-primary-foreground shadow-sm'
-                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                  collapsed && 'justify-center'
-                )}
-                aria-current={isActive ? 'page' : undefined}
-                title={collapsed ? item.name : undefined}
-              >
-                <item.icon className="h-5 w-5 flex-shrink-0" />
-                {!collapsed && (
-                  <span className="whitespace-nowrap">{item.name}</span>
-                )}
-              </Link>
-            )
-          })}
+        <nav className="flex-1 space-y-4 overflow-y-auto px-3 py-4">
+          {groups.map((group) => (
+            <div key={group.label} className="space-y-1">
+              {!collapsed && (
+                <p className="px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                  {group.label}
+                </p>
+              )}
+              {group.items.map((item) => {
+                const isActive = isRouteActive(pathname, item.href)
+                return (
+                  <Link
+                    key={item.name}
+                    href={item.href}
+                    prefetch={true}
+                    className={cn(
+                      'group flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-[color,background-color,transform] duration-150',
+                      'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                      isActive
+                        ? 'bg-primary text-primary-foreground shadow-sm'
+                        : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                      collapsed && 'justify-center'
+                    )}
+                    aria-current={isActive ? 'page' : undefined}
+                    title={collapsed ? item.name : undefined}
+                  >
+                    <item.icon className="h-5 w-5 flex-shrink-0" />
+                    {!collapsed && (
+                      <span className="whitespace-nowrap">{item.name}</span>
+                    )}
+                  </Link>
+                )
+              })}
+            </div>
+          ))}
         </nav>
         <div className="border-t px-3 py-3">
           <Button
@@ -165,8 +219,8 @@ export function Sidebar() {
         style={{ paddingBottom: 'max(0.5rem, env(safe-area-inset-bottom, 0px))' }}
         suppressHydrationWarning
       >
-        <div className="grid grid-cols-4 gap-1 sm:gap-1.5 px-2 sm:px-3 py-1">
-          {mobilePrimaryNav.map((item) => {
+        <div className="grid grid-cols-5 gap-1 px-2 py-1">
+          {mobilePrimary.map((item) => {
             const isActive = isRouteActive(pathname, item.href)
             return (
               <Link
@@ -183,10 +237,23 @@ export function Sidebar() {
                 aria-current={isActive ? 'page' : undefined}
               >
                 <item.icon className={cn('h-4 w-4 flex-shrink-0 transition-transform duration-100', isActive && 'scale-110')} />
-                <span className="text-[10px] font-medium text-center leading-tight">{'mobileLabel' in item ? item.mobileLabel : item.name}</span>
+                <span className="text-[10px] font-medium text-center leading-tight">{item.mobileLabel ?? item.name}</span>
               </Link>
             )
           })}
+          <button
+            type="button"
+            onClick={openQuickAdd}
+            className={cn(
+              'flex flex-col items-center justify-center gap-0.5 rounded-xl border py-1 px-1 min-h-[36px] touch-manipulation transition-[transform,color,background-color,border-color] duration-100 ease-out active:scale-95',
+              'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+              'bg-primary text-primary-foreground border-primary font-semibold',
+            )}
+            aria-label="Quick add"
+          >
+            <Plus className="h-4 w-4 flex-shrink-0" />
+            <span className="text-[10px] font-medium text-center leading-tight">Add</span>
+          </button>
           <Dialog open={moreOpen} onOpenChange={setMoreOpen}>
             <DialogTrigger asChild>
               <button
@@ -194,7 +261,8 @@ export function Sidebar() {
                 className={cn(
                   'flex flex-col items-center justify-center gap-0.5 rounded-xl border py-1 px-1 min-h-[36px] touch-manipulation transition-[transform,color,background-color,border-color] duration-100 ease-out active:scale-95',
                   'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-                  mobileMoreNav.some((item) => isRouteActive(pathname, item.href))
+                  groups.some((g) => g.items.some((item) => isRouteActive(pathname, item.href)))
+                    && !mobilePrimary.some((item) => isRouteActive(pathname, item.href))
                     ? 'bg-primary text-primary-foreground border-primary font-semibold'
                     : 'bg-muted/50 text-muted-foreground border-border hover:bg-muted'
                 )}
@@ -206,51 +274,58 @@ export function Sidebar() {
                 <span className="text-[10px] font-medium text-center leading-tight">More</span>
               </button>
             </DialogTrigger>
-            <DialogContent className="fixed left-0 right-0 bottom-0 top-auto z-[130] max-h-[70vh] w-full translate-x-0 translate-y-0 rounded-t-2xl border-b-0 gap-0 p-0 sm:max-w-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
+            <DialogContent className="fixed left-0 right-0 bottom-0 top-auto z-[130] max-h-[80vh] w-full translate-x-0 translate-y-0 rounded-t-2xl border-b-0 gap-0 p-0 sm:max-w-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
               <DialogHeader className="px-4 pt-4 pb-2">
                 <DialogTitle>More</DialogTitle>
               </DialogHeader>
               <div className="overflow-y-auto px-4 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))]">
-                <div className="flex flex-col gap-1">
-                  <button
-                    type="button"
-                    onClick={openMobileAssistant}
-                    className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition-[transform,color,background-color] duration-100 ease-out active:scale-[0.98] hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                  >
-                    <MessageCircle className="h-5 w-5 flex-shrink-0" />
-                    AI Assistant
-                  </button>
-                  {mobileMoreNav.map((item) => {
-                    const isActive = isRouteActive(pathname, item.href)
-                    return (
-                      <Link
-                        key={item.name}
-                        href={item.href}
-                        prefetch={true}
-                        onClick={() => setMoreOpen(false)}
-                        className={cn(
-                          'flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition-[transform,color,background-color] duration-100 ease-out active:scale-[0.98]',
-                          'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-                          isActive
-                            ? 'bg-primary text-primary-foreground'
-                            : 'hover:bg-muted'
-                        )}
-                        aria-current={isActive ? 'page' : undefined}
-                      >
-                        <item.icon className="h-5 w-5 flex-shrink-0" />
-                        {item.name}
-                      </Link>
-                    )
-                  })}
-                  <button
-                    type="button"
-                    onClick={handleLogout}
-                    className="mt-2 flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium text-red-600 transition-[transform,color,background-color] duration-100 ease-out active:scale-[0.98] hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-red-400"
-                  >
-                    <LogOut className="h-5 w-5 flex-shrink-0" />
-                    Log out
-                  </button>
+                <button
+                  type="button"
+                  onClick={openMobileAssistant}
+                  className="mb-3 flex w-full items-center gap-3 rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-sm font-medium text-foreground transition-[transform,color,background-color] duration-100 ease-out active:scale-[0.98] hover:bg-primary/10 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                >
+                  <MessageCircle className="h-5 w-5 flex-shrink-0 text-primary" />
+                  AI Assistant
+                </button>
+                <div className="space-y-4">
+                  {groups.map((group) => (
+                    <div key={group.label} className="space-y-1">
+                      <p className="px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                        {group.label}
+                      </p>
+                      {group.items.map((item) => {
+                        const isActive = isRouteActive(pathname, item.href)
+                        return (
+                          <Link
+                            key={item.name}
+                            href={item.href}
+                            prefetch={true}
+                            onClick={() => setMoreOpen(false)}
+                            className={cn(
+                              'flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition-[transform,color,background-color] duration-100 ease-out active:scale-[0.98]',
+                              'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                              isActive
+                                ? 'bg-primary text-primary-foreground'
+                                : 'hover:bg-muted'
+                            )}
+                            aria-current={isActive ? 'page' : undefined}
+                          >
+                            <item.icon className="h-5 w-5 flex-shrink-0" />
+                            {item.name}
+                          </Link>
+                        )
+                      })}
+                    </div>
+                  ))}
                 </div>
+                <button
+                  type="button"
+                  onClick={handleLogout}
+                  className="mt-4 flex w-full items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium text-red-600 transition-[transform,color,background-color] duration-100 ease-out active:scale-[0.98] hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-red-400"
+                >
+                  <LogOut className="h-5 w-5 flex-shrink-0" />
+                  Log out
+                </button>
               </div>
             </DialogContent>
           </Dialog>

--- a/components/summary/summary-page-content.tsx
+++ b/components/summary/summary-page-content.tsx
@@ -10,6 +10,7 @@ import { useChartTheme } from '@/lib/hooks/use-chart-theme'
 import { getChartTooltipContentStyle, getChartTooltipWrapperStyle } from '@/lib/chart-styles'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader } from '@/components/ui/page-header'
 import { BudgetTarget, MonthlyTrend, AnnualTrend } from '@/lib/types'
 import { getDefaultForecastMethods } from '@/lib/forecasting'
 import { isExpenseCategory } from '@/lib/category-filters'
@@ -552,17 +553,15 @@ export function SummaryPageContent() {
 
   return (
     <>
-      <div className="hidden md:block rounded-xl border border-l-[3px] border-l-indigo-500 bg-gradient-to-r from-muted/50 to-muted/30 p-4 md:p-5">
-        <div className="space-y-1">
-          <h1 className="text-2xl md:text-3xl font-bold">Daily Summary</h1>
-          <p className="text-sm md:text-base text-muted-foreground">
-            <span>{todayFormatted}</span>
-            {lastSyncDate && (
-              <span className="text-muted-foreground/70"> · Updated {formatLastSync()}</span>
-            )}
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        title="Daily Summary"
+        description={
+          lastSyncDate
+            ? `${todayFormatted} · Updated ${formatLastSync()}`
+            : todayFormatted
+        }
+        accent="indigo"
+      />
 
       <div>
         {loading ? (

--- a/components/sync-status-pill.tsx
+++ b/components/sync-status-pill.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { cn } from '@/utils/cn'
+import { useSync } from '@/lib/contexts/sync-context'
+
+interface SyncStatusPillProps {
+  className?: string
+}
+
+export function SyncStatusPill({ className }: SyncStatusPillProps) {
+  const { syncing, ingestionStatus, lastRefreshDate, formatLastSheetSync } = useSync()
+
+  const freshness = ingestionStatus?.freshness ?? null
+
+  let label: string
+  let dotClass: string
+  let pillClass: string
+
+  if (syncing) {
+    label = 'Syncing…'
+    dotClass = 'bg-blue-500 animate-pulse'
+    pillClass = 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300'
+  } else if (freshness === 'setup') {
+    label = 'Add a source'
+    dotClass = 'bg-amber-500'
+    pillClass = 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+  } else if (freshness === 'stale') {
+    label = `Stale · ${formatLastSheetSync(lastRefreshDate)}`
+    dotClass = 'bg-amber-500'
+    pillClass = 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+  } else if (freshness === 'fresh') {
+    label = `Fresh · ${formatLastSheetSync(lastRefreshDate)}`
+    dotClass = 'bg-emerald-500'
+    pillClass = 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+  } else {
+    label = formatLastSheetSync(lastRefreshDate)
+    dotClass = 'bg-muted-foreground'
+    pillClass = 'border-border bg-muted text-muted-foreground'
+  }
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium whitespace-nowrap',
+        pillClass,
+        className,
+      )}
+      title={ingestionStatus?.freshnessLabel ?? undefined}
+    >
+      <span className={cn('inline-block h-1.5 w-1.5 rounded-full', dotClass)} aria-hidden />
+      {label}
+    </span>
+  )
+}

--- a/components/transactions/add-transaction-dialog.tsx
+++ b/components/transactions/add-transaction-dialog.tsx
@@ -16,10 +16,25 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 
-export function AddTransactionDialog() {
+interface AddTransactionDialogProps {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  hideTrigger?: boolean
+}
+
+export function AddTransactionDialog({
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
+  hideTrigger = false,
+}: AddTransactionDialogProps = {}) {
   const router = useRouter()
   const queryClient = useQueryClient()
-  const [open, setOpen] = useState(false)
+  const [internalOpen, setInternalOpen] = useState(false)
+  const open = controlledOpen ?? internalOpen
+  const setOpen = (v: boolean) => {
+    if (controlledOnOpenChange) controlledOnOpenChange(v)
+    else setInternalOpen(v)
+  }
   const [saving, setSaving] = useState(false)
 
   const today = new Date().toISOString().split('T')[0]
@@ -87,12 +102,14 @@ export function AddTransactionDialog() {
 
   return (
     <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) resetForm() }}>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="sm">
-          <Plus className="h-4 w-4 mr-1" />
-          Add Transaction
-        </Button>
-      </DialogTrigger>
+      {!hideTrigger && (
+        <DialogTrigger asChild>
+          <Button variant="outline" size="sm">
+            <Plus className="h-4 w-4 mr-1" />
+            Add Transaction
+          </Button>
+        </DialogTrigger>
+      )}
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Add Transaction</DialogTitle>

--- a/components/transactions/filtered-totals-row.tsx
+++ b/components/transactions/filtered-totals-row.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react'
+import { cn } from '@/utils/cn'
+
+interface FilteredTotalsRowProps {
+  count: number
+  totalIn: number
+  totalOut: number
+  net: number
+  priorNet: number | null
+  symbol: string
+}
+
+function formatMoney(value: number, symbol: string) {
+  const prefix = value < 0 ? '-' : ''
+  return `${prefix}${symbol}${Math.abs(value).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`
+}
+
+function formatDelta(value: number, symbol: string) {
+  const sign = value > 0 ? '+' : value < 0 ? '−' : ''
+  return `${sign}${symbol}${Math.abs(value).toLocaleString(undefined, {
+    maximumFractionDigits: 0,
+  })}`
+}
+
+export function FilteredTotalsRow({
+  count,
+  totalIn,
+  totalOut,
+  net,
+  priorNet,
+  symbol,
+}: FilteredTotalsRowProps) {
+  const delta = priorNet == null ? null : net - priorNet
+  const DeltaIcon = delta == null || delta === 0 ? Minus : delta > 0 ? TrendingUp : TrendingDown
+
+  return (
+    <div className="rounded-lg border bg-card p-3 md:p-4">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-6">
+        <div>
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Transactions</p>
+          <p className="text-lg font-semibold">{count.toLocaleString()}</p>
+        </div>
+        <div>
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">In</p>
+          <p className="text-lg font-semibold text-emerald-600 dark:text-emerald-400">
+            {formatMoney(totalIn, symbol)}
+          </p>
+        </div>
+        <div>
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Out</p>
+          <p className="text-lg font-semibold text-foreground">
+            {formatMoney(-Math.abs(totalOut), symbol)}
+          </p>
+        </div>
+        <div>
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Net</p>
+          <div className="flex items-baseline gap-2">
+            <p
+              className={cn(
+                'text-lg font-semibold',
+                net >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-foreground',
+              )}
+            >
+              {formatMoney(net, symbol)}
+            </p>
+            {delta != null && (
+              <span
+                className={cn(
+                  'inline-flex items-center gap-0.5 text-xs',
+                  delta === 0
+                    ? 'text-muted-foreground'
+                    : delta > 0
+                      ? 'text-emerald-600 dark:text-emerald-400'
+                      : 'text-red-600 dark:text-red-400',
+                )}
+                title="vs comparable prior period"
+              >
+                <DeltaIcon className="h-3 w-3" aria-hidden />
+                {formatDelta(delta, symbol)}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/transactions/transactions-filter-bar.tsx
+++ b/components/transactions/transactions-filter-bar.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Search, Filter, X } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/utils/cn'
+import { DATE_PRESETS, type DatePresetId } from '@/lib/date-presets'
+
+export interface TransactionFilterValue {
+  search: string
+  preset: DatePresetId
+  categories: string[]
+}
+
+interface TransactionFilterBarProps {
+  value: TransactionFilterValue
+  onChange: (value: TransactionFilterValue) => void
+  availableCategories: string[]
+}
+
+export function TransactionFilterBar({
+  value,
+  onChange,
+  availableCategories,
+}: TransactionFilterBarProps) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClickOutside(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [open])
+
+  const activeFiltersCount =
+    (value.preset === 'last-3-months' ? 0 : 1) + value.categories.length
+
+  const toggleCategory = (cat: string) => {
+    const next = value.categories.includes(cat)
+      ? value.categories.filter((c) => c !== cat)
+      : [...value.categories, cat]
+    onChange({ ...value, categories: next })
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            placeholder="Search counterparty or category"
+            value={value.search}
+            onChange={(e) => onChange({ ...value, search: e.target.value })}
+            className="pl-9"
+          />
+        </div>
+        <div className="relative" ref={containerRef}>
+          <Button
+            variant="outline"
+            size="icon"
+            className="relative h-10 w-10 rounded-full shrink-0"
+            onClick={() => setOpen(!open)}
+            aria-label="Filter"
+            aria-expanded={open}
+          >
+            <Filter className="h-4 w-4" />
+            {activeFiltersCount > 0 && (
+              <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-primary-foreground">
+                {activeFiltersCount}
+              </span>
+            )}
+          </Button>
+          {open && (
+            <div className="absolute right-0 top-full z-30 mt-2 w-72 rounded-lg border bg-popover p-3 shadow-lg">
+              <div className="space-y-3">
+                <div>
+                  <p className="mb-1.5 text-xs font-medium text-muted-foreground">Date range</p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {DATE_PRESETS.map((p) => (
+                      <Button
+                        key={p.id}
+                        variant={value.preset === p.id ? 'default' : 'outline'}
+                        size="sm"
+                        className="text-xs"
+                        onClick={() => onChange({ ...value, preset: p.id })}
+                      >
+                        {p.label}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+                {availableCategories.length > 0 && (
+                  <div>
+                    <div className="mb-1.5 flex items-center justify-between">
+                      <p className="text-xs font-medium text-muted-foreground">Categories</p>
+                      {value.categories.length > 0 && (
+                        <button
+                          type="button"
+                          className="text-xs text-muted-foreground hover:text-foreground"
+                          onClick={() => onChange({ ...value, categories: [] })}
+                        >
+                          Clear
+                        </button>
+                      )}
+                    </div>
+                    <div className="max-h-56 overflow-y-auto rounded-md border bg-background p-1.5">
+                      {availableCategories.map((cat) => {
+                        const checked = value.categories.includes(cat)
+                        return (
+                          <label
+                            key={cat}
+                            className={cn(
+                              'flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted',
+                              checked && 'bg-muted',
+                            )}
+                          >
+                            <input
+                              type="checkbox"
+                              className="h-3.5 w-3.5 accent-primary"
+                              checked={checked}
+                              onChange={() => toggleCategory(cat)}
+                            />
+                            <span className="truncate">{cat}</span>
+                          </label>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+      {value.categories.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {value.categories.map((cat) => (
+            <button
+              key={cat}
+              type="button"
+              onClick={() => toggleCategory(cat)}
+              className="inline-flex items-center gap-1 rounded-full border bg-muted px-2.5 py-0.5 text-xs font-medium hover:bg-muted/70"
+              aria-label={`Remove ${cat} filter`}
+            >
+              {cat}
+              <X className="h-3 w-3" aria-hidden />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/transactions/transactions-list.tsx
+++ b/components/transactions/transactions-list.tsx
@@ -1,36 +1,82 @@
 'use client'
 
-import { useEffect, useState, useMemo, useRef } from 'react'
+import { useEffect, useState, useMemo } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { TransactionLog } from '@/lib/types'
 import { useCurrency } from '@/lib/contexts/currency-context'
-import { Input } from '@/components/ui/input'
-import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
-import { Search, Filter, Receipt } from 'lucide-react'
+import { Receipt } from 'lucide-react'
 import { cn } from '@/utils/cn'
 import { useTransactions } from '@/lib/hooks/queries/use-transactions'
+import {
+  DATE_PRESETS,
+  fetchDaysForPreset,
+  getPriorWindow,
+  getWindowForPreset,
+  isInWindow,
+  type DatePresetId,
+} from '@/lib/date-presets'
+import {
+  TransactionFilterBar,
+  type TransactionFilterValue,
+} from './transactions-filter-bar'
+import { FilteredTotalsRow } from './filtered-totals-row'
 
-const DATE_RANGE_OPTIONS = [
-  { label: 'Last 7 days', days: 7 },
-  { label: 'Last 30 days', days: 30 },
-  { label: 'Last 90 days', days: 90 },
-  { label: 'All', days: null },
-] as const
+const VALID_PRESET_IDS = new Set<DatePresetId>(DATE_PRESETS.map((p) => p.id))
+
+function readPreset(value: string | null): DatePresetId {
+  if (value && VALID_PRESET_IDS.has(value as DatePresetId)) return value as DatePresetId
+  return 'last-3-months'
+}
+
+function readCategories(value: string | null): string[] {
+  if (!value) return []
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
 
 export function TransactionsList() {
   const { currency, fxRate } = useCurrency()
-  const [searchQuery, setSearchQuery] = useState('')
-  const [dateRangeDays, setDateRangeDays] = useState<number | null>(90)
-  const [selectedCategory, setSelectedCategory] = useState<string>('')
-  const [filterOpen, setFilterOpen] = useState(false)
-  const filterRef = useRef<HTMLDivElement>(null)
+  const router = useRouter()
+  const searchParams = useSearchParams()
 
-  const { data: transactions = [], isLoading: loading, error: queryError } = useTransactions(dateRangeDays)
+  const initialFilter = useMemo<TransactionFilterValue>(
+    () => ({
+      search: searchParams.get('q') ?? '',
+      preset: readPreset(searchParams.get('range')),
+      categories: readCategories(searchParams.get('cat')),
+    }),
+    // Initialize from URL once on mount; subsequent updates flow through onChange.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  )
+  const [filter, setFilter] = useState<TransactionFilterValue>(initialFilter)
+
+  // Reflect filter into URL so views are shareable.
+  useEffect(() => {
+    const params = new URLSearchParams()
+    if (filter.search) params.set('q', filter.search)
+    if (filter.preset !== 'last-3-months') params.set('range', filter.preset)
+    if (filter.categories.length > 0) params.set('cat', filter.categories.join(','))
+    const next = params.toString()
+    const current = searchParams.toString()
+    if (next !== current) {
+      router.replace(next ? `?${next}` : '?', { scroll: false })
+    }
+  }, [filter, router, searchParams])
+
+  const fetchDays = useMemo(() => fetchDaysForPreset(filter.preset), [filter.preset])
+  const { data: transactions = [], isLoading: loading, error: queryError } =
+    useTransactions(fetchDays)
   const error = queryError?.message ?? null
 
-  // Unique categories from fetched data (for filter dropdown)
-  const categories = useMemo(() => {
+  const window = useMemo(() => getWindowForPreset(filter.preset), [filter.preset])
+  const priorWindow = useMemo(() => (window ? getPriorWindow(window) : null), [window])
+
+  const availableCategories = useMemo(() => {
     const set = new Set<string>()
     transactions.forEach((t) => {
       if (t.category?.trim()) set.add(t.category.trim())
@@ -38,42 +84,64 @@ export function TransactionsList() {
     return Array.from(set).sort()
   }, [transactions])
 
-  // Reset selected category if not in list
-  useEffect(() => {
-    if (categories.length > 0 && selectedCategory && !categories.includes(selectedCategory)) {
-      setSelectedCategory('')
-    }
-  }, [categories, selectedCategory])
-
-  // Filter by search and category
   const filteredTransactions = useMemo(() => {
-    const q = searchQuery.trim().toLowerCase()
+    const q = filter.search.trim().toLowerCase()
+    const catFilter = new Set(filter.categories)
     return transactions.filter((t) => {
+      if (!isInWindow(t.date, window)) return false
       const matchSearch =
         !q ||
         (t.counterparty?.toLowerCase().includes(q) ?? false) ||
         (t.category?.toLowerCase().includes(q) ?? false)
-      const matchCategory = !selectedCategory || (t.category?.trim() === selectedCategory)
+      const matchCategory = catFilter.size === 0 || (t.category && catFilter.has(t.category.trim()))
       return matchSearch && matchCategory
     })
-  }, [transactions, searchQuery, selectedCategory])
+  }, [transactions, filter.search, filter.categories, window])
 
-  // Total of displayed transactions in display currency
-  const totalDisplay = useMemo(() => {
-    let sum = 0
-    for (const t of filteredTransactions) {
+  const priorTransactions = useMemo(() => {
+    if (!priorWindow) return [] as TransactionLog[]
+    const q = filter.search.trim().toLowerCase()
+    const catFilter = new Set(filter.categories)
+    return transactions.filter((t) => {
+      if (!isInWindow(t.date, priorWindow)) return false
+      const matchSearch =
+        !q ||
+        (t.counterparty?.toLowerCase().includes(q) ?? false) ||
+        (t.category?.toLowerCase().includes(q) ?? false)
+      const matchCategory = catFilter.size === 0 || (t.category && catFilter.has(t.category.trim()))
+      return matchSearch && matchCategory
+    })
+  }, [transactions, filter.search, filter.categories, priorWindow])
+
+  const toDisplay = useMemo(() => {
+    return (t: TransactionLog) => {
       const gbp = t.amount_gbp ?? 0
       const usd = t.amount_usd ?? 0
       const hasGbp = t.amount_gbp != null
       const amountInGbp = hasGbp ? gbp : usd / (fxRate || 1)
       const amountInUsd = hasGbp ? gbp * (fxRate || 1) : usd
-      const displayValue = currency === 'GBP' ? amountInGbp : amountInUsd
-      sum += displayValue
+      return currency === 'GBP' ? amountInGbp : amountInUsd
     }
-    return sum
-  }, [filteredTransactions, currency, fxRate])
+  }, [currency, fxRate])
 
-  // Group filtered transactions by day (date string YYYY-MM-DD), sorted newest first
+  const totals = useMemo(() => {
+    let totalIn = 0
+    let totalOut = 0
+    for (const t of filteredTransactions) {
+      const v = toDisplay(t)
+      if (v >= 0) totalIn += v
+      else totalOut += v
+    }
+    return { totalIn, totalOut, net: totalIn + totalOut }
+  }, [filteredTransactions, toDisplay])
+
+  const priorNet = useMemo(() => {
+    if (!priorWindow || priorTransactions.length === 0) return null
+    let sum = 0
+    for (const t of priorTransactions) sum += toDisplay(t)
+    return sum
+  }, [priorTransactions, priorWindow, toDisplay])
+
   const transactionsByDay = useMemo(() => {
     const byDay = new Map<string, TransactionLog[]>()
     for (const t of filteredTransactions) {
@@ -85,6 +153,8 @@ export function TransactionsList() {
     return sortedDates.map((dateStr) => ({ dateStr, transactions: byDay.get(dateStr)! }))
   }, [filteredTransactions])
 
+  const symbol = currency === 'GBP' ? '£' : '$'
+
   const formatDayHeader = (dateStr: string): string => {
     const [y, m, d] = dateStr.split('-').map(Number)
     const date = new Date(y, (m ?? 1) - 1, d ?? 1)
@@ -93,44 +163,17 @@ export function TransactionsList() {
 
   const getDayTotal = (dayTransactions: TransactionLog[]): number => {
     let sum = 0
-    for (const t of dayTransactions) {
-      const gbp = t.amount_gbp ?? 0
-      const usd = t.amount_usd ?? 0
-      const hasGbp = t.amount_gbp != null
-      const amountInGbp = hasGbp ? gbp : usd / (fxRate || 1)
-      const amountInUsd = hasGbp ? gbp * (fxRate || 1) : usd
-      sum += currency === 'GBP' ? amountInGbp : amountInUsd
-    }
+    for (const t of dayTransactions) sum += toDisplay(t)
     return sum
   }
 
   const formatTotal = (value: number): string => {
     const prefix = value < 0 ? '-' : ''
-    const symbol = currency === 'GBP' ? '£' : '$'
     return `${prefix}${symbol}${Math.abs(value).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
   }
 
-  // Close filter when clicking outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (filterRef.current && !filterRef.current.contains(event.target as Node)) {
-        setFilterOpen(false)
-      }
-    }
-    if (filterOpen) {
-      document.addEventListener('mousedown', handleClickOutside)
-      return () => document.removeEventListener('mousedown', handleClickOutside)
-    }
-  }, [filterOpen])
-
   const formatAmount = (t: TransactionLog): string => {
-    const gbp = t.amount_gbp ?? 0
-    const usd = t.amount_usd ?? 0
-    const hasGbp = t.amount_gbp != null
-    const amountInGbp = hasGbp ? gbp : usd / (fxRate || 1)
-    const amountInUsd = hasGbp ? gbp * (fxRate || 1) : usd
-    const value = currency === 'GBP' ? amountInGbp : amountInUsd
-    const symbol = currency === 'GBP' ? '£' : '$'
+    const value = toDisplay(t)
     const formatted = Math.abs(value).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
     const prefix = value < 0 ? '-' : ''
     return `${prefix}${symbol}${formatted}`
@@ -144,87 +187,24 @@ export function TransactionsList() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl md:text-3xl font-bold">Transactions</h1>
+      <TransactionFilterBar
+        value={filter}
+        onChange={setFilter}
+        availableCategories={availableCategories}
+      />
 
-      <div className="flex gap-2">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="search"
-            placeholder="Search"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-9"
-          />
-        </div>
-        <div className="relative" ref={filterRef}>
-          <Button
-            variant="outline"
-            size="icon"
-            className="h-10 w-10 rounded-full shrink-0"
-            onClick={() => setFilterOpen(!filterOpen)}
-            aria-label="Filter"
-          >
-            <Filter className="h-4 w-4" />
-          </Button>
-          {filterOpen && (
-            <div className="absolute right-0 top-full z-10 mt-2 w-56 rounded-lg border bg-popover p-3 shadow-md">
-              <div className="space-y-3">
-                <div>
-                  <p className="mb-1.5 text-xs font-medium text-muted-foreground">Date range</p>
-                  <div className="flex flex-wrap gap-1.5">
-                    {DATE_RANGE_OPTIONS.map((opt) => (
-                      <Button
-                        key={opt.label}
-                        variant={dateRangeDays === opt.days ? 'default' : 'outline'}
-                        size="sm"
-                        className="text-xs"
-                        onClick={() => {
-                          setDateRangeDays(opt.days)
-                        }}
-                      >
-                        {opt.label}
-                      </Button>
-                    ))}
-                  </div>
-                </div>
-                {categories.length > 0 && (
-                  <div>
-                    <p className="mb-1.5 text-xs font-medium text-muted-foreground">Category</p>
-                    <select
-                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                      value={selectedCategory}
-                      onChange={(e) => setSelectedCategory(e.target.value)}
-                    >
-                      <option value="">All categories</option>
-                      {categories.map((cat) => (
-                        <option key={cat} value={cat}>
-                          {cat}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h2 className="text-lg font-semibold">Recent transactions</h2>
-        {!loading && (
-          <span className={cn('text-sm font-medium', totalDisplay < 0 ? 'text-foreground' : 'text-muted-foreground')}>
-            {totalDisplay < 0 ? '-' : ''}
-            {currency === 'GBP' ? '£' : '$'}
-            {Math.abs(totalDisplay).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-          </span>
-        )}
-      </div>
-
-      {error && (
-        <p className="text-sm text-destructive">{error}</p>
+      {!loading && filteredTransactions.length > 0 && (
+        <FilteredTotalsRow
+          count={filteredTransactions.length}
+          totalIn={totals.totalIn}
+          totalOut={totals.totalOut}
+          net={totals.net}
+          priorNet={priorNet}
+          symbol={symbol}
+        />
       )}
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
 
       {loading ? (
         <div className="space-y-3">
@@ -245,8 +225,8 @@ export function TransactionsList() {
           title="No transactions"
           description={
             transactions.length === 0
-              ? "No transactions in the selected date range."
-              : "No transactions match your search or filter."
+              ? 'No transactions in the selected date range.'
+              : 'No transactions match your search or filter.'
           }
         />
       ) : (
@@ -262,7 +242,7 @@ export function TransactionsList() {
                   <span
                     className={cn(
                       'text-sm font-medium',
-                      dayTotal < 0 ? 'text-foreground' : 'text-muted-foreground'
+                      dayTotal < 0 ? 'text-foreground' : 'text-muted-foreground',
                     )}
                   >
                     {formatTotal(dayTotal)}

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description?: ReactNode
+  confirmLabel?: string
+  cancelLabel?: string
+  destructive?: boolean
+  onConfirm: () => void | Promise<void>
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive = false,
+  onConfirm,
+}: ConfirmDialogProps) {
+  const [running, setRunning] = useState(false)
+
+  const handleConfirm = async () => {
+    setRunning(true)
+    try {
+      await onConfirm()
+      onOpenChange(false)
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !running && onOpenChange(o)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={running}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant={destructive ? 'destructive' : 'default'}
+            onClick={handleConfirm}
+            disabled={running}
+          >
+            {running ? `${confirmLabel}...` : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/ui/page-header.tsx
+++ b/components/ui/page-header.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/utils/cn'
+
+type Accent = 'blue' | 'purple' | 'violet' | 'indigo' | 'slate' | 'orange' | 'emerald' | 'none'
+
+const ACCENT_CLASSES: Record<Accent, string> = {
+  blue: 'border-l-[3px] border-l-blue-500',
+  purple: 'border-l-[3px] border-l-purple-500',
+  violet: 'border-l-[3px] border-l-violet-500',
+  indigo: 'border-l-[3px] border-l-indigo-500',
+  slate: 'border-l-[3px] border-l-slate-500',
+  orange: 'border-l-[3px] border-l-orange-500',
+  emerald: 'border-l-[3px] border-l-emerald-500',
+  none: '',
+}
+
+interface PageHeaderProps {
+  title: string
+  description?: string
+  accent?: Accent
+  badges?: ReactNode
+  actions?: ReactNode
+  className?: string
+}
+
+export function PageHeader({
+  title,
+  description,
+  accent = 'slate',
+  badges,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-xl border bg-gradient-to-r from-muted/50 to-muted/30 p-4 md:p-5',
+        ACCENT_CLASSES[accent],
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div className="min-w-0 space-y-1.5">
+          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">{title}</h1>
+          {description && (
+            <p className="text-sm md:text-base text-muted-foreground">{description}</p>
+          )}
+          {badges && <div className="flex flex-wrap gap-2 pt-1 text-xs">{badges}</div>}
+        </div>
+        {actions && (
+          <div className="flex shrink-0 flex-wrap items-center gap-2 md:justify-end">{actions}</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function PageHeaderBadge({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-full border bg-background px-2.5 py-1 font-medium">{children}</span>
+  )
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn("skeleton-shimmer rounded-md bg-muted", className)}
       {...props}
     />
   )

--- a/lib/date-presets.ts
+++ b/lib/date-presets.ts
@@ -1,0 +1,95 @@
+export type DatePresetId =
+  | 'this-month'
+  | 'last-month'
+  | 'last-3-months'
+  | 'ytd'
+  | 'last-12-months'
+  | 'all'
+
+export interface DatePreset {
+  id: DatePresetId
+  label: string
+  shortLabel: string
+}
+
+export const DATE_PRESETS: DatePreset[] = [
+  { id: 'this-month', label: 'This month', shortLabel: 'MTD' },
+  { id: 'last-month', label: 'Last month', shortLabel: 'Last mo' },
+  { id: 'last-3-months', label: 'Last 3 months', shortLabel: '3 mo' },
+  { id: 'ytd', label: 'Year to date', shortLabel: 'YTD' },
+  { id: 'last-12-months', label: 'Last 12 months', shortLabel: '12 mo' },
+  { id: 'all', label: 'All time', shortLabel: 'All' },
+]
+
+export interface DateWindow {
+  start: Date
+  end: Date
+}
+
+function startOfDay(date: Date): Date {
+  const out = new Date(date)
+  out.setHours(0, 0, 0, 0)
+  return out
+}
+
+function endOfDay(date: Date): Date {
+  const out = new Date(date)
+  out.setHours(23, 59, 59, 999)
+  return out
+}
+
+export function getWindowForPreset(preset: DatePresetId, now = new Date()): DateWindow | null {
+  const today = startOfDay(now)
+  switch (preset) {
+    case 'this-month': {
+      const start = new Date(today.getFullYear(), today.getMonth(), 1)
+      return { start, end: endOfDay(today) }
+    }
+    case 'last-month': {
+      const start = new Date(today.getFullYear(), today.getMonth() - 1, 1)
+      const end = new Date(today.getFullYear(), today.getMonth(), 0, 23, 59, 59, 999)
+      return { start, end }
+    }
+    case 'last-3-months': {
+      const start = new Date(today.getFullYear(), today.getMonth() - 2, 1)
+      return { start, end: endOfDay(today) }
+    }
+    case 'ytd': {
+      const start = new Date(today.getFullYear(), 0, 1)
+      return { start, end: endOfDay(today) }
+    }
+    case 'last-12-months': {
+      const start = new Date(today)
+      start.setMonth(start.getMonth() - 12)
+      return { start: startOfDay(start), end: endOfDay(today) }
+    }
+    case 'all':
+      return null
+  }
+}
+
+/** The comparable prior period of the same length, ending the day before `window.start`. */
+export function getPriorWindow(window: DateWindow): DateWindow {
+  const lengthMs = window.end.getTime() - window.start.getTime()
+  const end = new Date(window.start.getTime() - 1)
+  const start = new Date(end.getTime() - lengthMs)
+  return { start, end }
+}
+
+/** Days back from today required to cover this preset (for fetching). */
+export function fetchDaysForPreset(preset: DatePresetId, now = new Date()): number | null {
+  const win = getWindowForPreset(preset, now)
+  if (!win) return null
+  const today = startOfDay(now)
+  const days = Math.ceil((today.getTime() - win.start.getTime()) / (1000 * 60 * 60 * 24))
+  // Double the window so we also have the comparable prior period available client-side.
+  const doubled = days * 2 + 7
+  return Math.max(doubled, 30)
+}
+
+export function isInWindow(dateStr: string, window: DateWindow | null): boolean {
+  if (!window) return true
+  const d = new Date(dateStr)
+  if (Number.isNaN(d.getTime())) return false
+  return d >= window.start && d <= window.end
+}


### PR DESCRIPTION
Implements the top 5 UI/UX improvements from the plan:

#4 Layout polish & loading
- New <PageHeader> with accent stripe, badges, actions; adopted on
  every top-level page (kills hidden-on-mobile patterns on /today, /,
  /insights).
- Replaces inline "Loading..." text with sized <Skeleton> placeholders
  in dashboard at-a-glance and 6 liquidity charts/tables so layout no
  longer reflows on data arrival.
- Subtle shimmer animation on Skeleton; tabular numerals applied
  globally via font-feature-settings: "tnum".

#3 Feedback foundations
- New reusable <ConfirmDialog>; wired into destructive deletes for
  accounts, debt, kids, recurring payment.
- New <SyncStatusPill> showing fresh/stale/setup/syncing as a colored
  pill (with dot) on both mobile and desktop headers.

#1 Exploration surfaces
- Shared <TransactionFilterBar> with date presets (this/last month,
  last 3, YTD, last 12, all), category multi-select, search; URL-state
  driven so filters are shareable.
- <FilteredTotalsRow> showing count + in/out/net + delta vs comparable
  prior period.
- <ForecastTopMovers>: top 5 categories trending higher / lower vs
  prior year actuals on the Forecast page.

#2 Sidebar & nav
- Sidebar grouped into Overview / Money / Planning / Setup with
  uppercase section labels.
- Mobile bottom nav restructured to 5 slots (Summary, Dashboard,
  Transactions, Add, More); More sheet now mirrors the grouped desktop
  nav with the AI Assistant pinned at the top.

#5 Quick Add + AI
- New <QuickAdd> launcher mounted globally; opens via ⌘K, the new
  desktop "Quick add" header button, or the mobile bottom-nav "Add"
  slot. Opens the controlled AddTransactionDialog inline; deep-links
  to the relevant page for accounts, recurring, debt, kids, import.
- AddTransactionDialog accepts controlled open/onOpenChange + hideTrigger.

https://claude.ai/code/session_01MrVroJ84obd6L88kyk5gP2